### PR TITLE
Lift [0, npieces) color space restriction in split.

### DIFF
--- a/include/quo-vadis.h
+++ b/include/quo-vadis.h
@@ -122,10 +122,16 @@ typedef enum qv_bind_string_format_e {
  */
 enum {
     /**
+     * Constant used to indicate undefined or unknown integer value. This means
+     * that the caller will not be considered in the split, and therefore
+     * receive an empty scope.
+     */
+    QV_SCOPE_SPLIT_UNDEFINED = -1,
+    /**
      * Split the provided group by attempting to preserve tasks' current
      * affinities (at time of the split call) as much as possible.
      */
-    QV_SCOPE_SPLIT_AFFINITY_PRESERVING = -1
+    QV_SCOPE_SPLIT_AFFINITY_PRESERVING = -2
 };
 
 /**

--- a/src/fortran/quo-vadisf.f90
+++ b/src/fortran/quo-vadisf.f90
@@ -1,5 +1,5 @@
 !
-! Copyright (c) 2013-2023 Triad National Security, LLC
+! Copyright (c) 2013-2024 Triad National Security, LLC
 !                         All rights reserved.
 !
 ! This file is part of the quo-vadis project. See the LICENSE file at the
@@ -111,9 +111,11 @@ module quo_vadisf
     !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
     ! Automatic grouping options for qv_scope_split().
     !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+    integer(c_int) QV_SCOPE_SPLIT_UNDEFINED
     integer(c_int) QV_SCOPE_SPLIT_AFFINITY_PRESERVING
 
-    parameter (QV_SCOPE_SPLIT_AFFINITY_PRESERVING = -1)
+    parameter (QV_SCOPE_SPLIT_UNDEFINED = -1)
+    parameter (QV_SCOPE_SPLIT_AFFINITY_PRESERVING = -2)
 
     !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
     ! Device ID types


### PR DESCRIPTION
Allow for the use of an arbitrary positive color space in splits. This lifts the requirement that colors be in [0, npieces).

Also include work on QV_SCOPE_SPLIT_UNDEFINED, but this is incomplete.