### PR TITLE
Update type of QV split constants.

### DIFF
--- a/include/quo-vadis.h
+++ b/include/quo-vadis.h
@@ -120,19 +120,18 @@ typedef enum qv_bind_string_format_e {
  * used instead of group_id to influence how automatic task grouping is
  * accomplished.
  */
-enum {
-    /**
-     * Constant used to indicate undefined or unknown integer value. This means
-     * that the caller will not be considered in the split, and therefore
-     * receive an empty scope.
-     */
-    QV_SCOPE_SPLIT_UNDEFINED = -1,
-    /**
-     * Split the provided group by attempting to preserve tasks' current
-     * affinities (at time of the split call) as much as possible.
-     */
-    QV_SCOPE_SPLIT_AFFINITY_PRESERVING = -2
-};
+
+/**
+ * Constant used to indicate undefined or unknown integer value. This means that
+ * the caller will not be considered in the split, and therefore receive an
+ * empty scope.
+ */
+const int QV_SCOPE_SPLIT_UNDEFINED = -1;
+/**
+ * Split the provided group by attempting to preserve tasks' current affinities
+ * (at time of the split call) as much as possible.
+ */
+const int QV_SCOPE_SPLIT_AFFINITY_PRESERVING = -2;
 
 /**
  *

--- a/tests/test-mpi-scope-ksplit.cc
+++ b/tests/test-mpi-scope-ksplit.cc
@@ -73,7 +73,10 @@ main(void)
     // Test internal APIs
     const uint_t npieces = ncores / 2;
     std::vector<int> colors(npieces * 2);
-    std::fill_n(colors.begin(), colors.size(), (int)QV_SCOPE_SPLIT_AFFINITY_PRESERVING);
+    std::fill_n(
+        colors.begin(), colors.size(),
+        QV_SCOPE_SPLIT_AFFINITY_PRESERVING
+    );
     //std::iota(colors.begin(), colors.end(), 0);
 
     std::vector<qv_scope_t *> subscopes;


### PR DESCRIPTION
Move to const int for predefined QV split types. This makes it clearer and avoids annoying casts in C++ code using QV.