### PR TITLE
Example showcasing the issue with threads and ZMQ Sockets

### DIFF
--- a/include/quo-vadis-thread.h
+++ b/include/quo-vadis-thread.h
@@ -97,6 +97,29 @@ qv_pthread_create(
     qv_context_t *ctx,
     qv_scope_t *scope
 );
+
+
+int
+qv_thread_scope_split_at(
+    qv_context_t *ctxt,
+    qv_scope_t *scope,
+    qv_hw_obj_type_t type,
+    int *color_array,
+    int nthreads,
+    qv_scope_t ***subscope
+);
+
+
+int
+qv_thread_scope_split(
+    qv_context_t *ctxt,
+    qv_scope_t *scope,
+    int npieces,
+    int *color_array,
+    int nthreads,
+    qv_scope_t ***subscope
+);
+
 #else
 /**                                                                                                     
  * Layout for fine-grain binding                                                                        

--- a/include/quo-vadis.h
+++ b/include/quo-vadis.h
@@ -106,7 +106,7 @@ typedef enum {
 } qv_hw_obj_type_t;
 
 /**
- * Binding string representaiton formats.
+ * Binding string representation formats.
  */
 typedef enum {
     QV_BIND_STRING_AS_BITMAP = 0,

--- a/src/qvi-context.cc
+++ b/src/qvi-context.cc
@@ -21,13 +21,18 @@ int
 qvi_context_new(
     qv_context_t **ctx
 ) {
-    return qvi_new_rc(ctx);
+    int rc = qvi_new_rc(ctx);
+    pthread_mutex_init(&(*ctx)->lock,NULL);
+    fprintf(stdout,"=================> mutex ctxt init done @%p\n",(void *)&(*ctx)->lock);
+    return rc;
+    //return qvi_new_rc(ctx);
 }
 
 void
 qvi_context_free(
     qv_context_t **ctx
 ) {
+    pthread_mutex_destroy(&(*ctx)->lock);
     qvi_delete(ctx);
 }
 

--- a/src/qvi-context.h
+++ b/src/qvi-context.h
@@ -33,6 +33,8 @@ struct qv_context_s {
     qvi_rmi_client_t *rmi = nullptr;
     qvi_zgroup_t *zgroup = nullptr;
     qvi_bind_stack_t *bind_stack = nullptr;
+    pthread_mutex_t lock;
+
     /** Constructor. */
     qv_context_s(void)
     {
@@ -51,6 +53,7 @@ struct qv_context_s {
         qvi_zgroup_free(&zgroup);
         qvi_rmi_client_free(&rmi);
     }
+
 };
 
 /**

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -154,6 +154,18 @@ if(MPI_FOUND)
         test-progress-thread
         quo-vadis
         quo-vadis-mpi
+	)
+
+    add_executable(
+        test-pthread-split
+        qvi-test-common.h
+        test-pthread-split.c
+    )
+
+    target_link_libraries(
+        test-pthread-split
+	quo-vadis
+        quo-vadis-mpi
     )
 
     add_executable(

--- a/tests/test-pthread-split.c
+++ b/tests/test-pthread-split.c
@@ -1,0 +1,189 @@
+/* -*- Mode: C; c-basic-offset:4; indent-tabs-mode:nil -*- */
+#include <stdio.h>
+#include <pthread.h>
+#include "quo-vadis-mpi.h"
+#include "quo-vadis-thread.h"
+#include "qvi-test-common.h"
+#include <assert.h>
+
+void *thread_work(void *arg)
+{
+    qv_context_t *ctx = (qv_context_t *) arg;
+    char *binds;
+    char const *ers = NULL;
+
+    int rc = qv_bind_string(ctx, QV_BIND_STRING_AS_LIST, &binds);
+
+    if (rc != QV_SUCCESS) {
+        ers = "qv_bind_string() failed";
+        qvi_test_panic("%s (rc=%s)", ers, qv_strerr(rc));
+    }
+
+    fprintf(stdout,"Thread running on %s\n", binds);
+    free(binds);
+
+
+    return NULL;
+}
+
+
+//int main(int argc, char *argv[])
+int
+main(void)
+{
+    char const *ers = NULL;
+    MPI_Comm comm = MPI_COMM_WORLD;
+    int wrank, wsize;
+    int n_numas, n_cores, n_pus, my_numa_id;
+    int rc = QV_SUCCESS;
+
+    fprintf(stdout,"# Starting Hybrid MPI + Pthreads test\n");
+
+    rc = MPI_Init(NULL, NULL);
+    if (rc != MPI_SUCCESS) {
+        ers = "MPI_Init() failed";
+        qvi_test_panic("%s (rc=%d)", ers, rc);
+    }
+
+    rc = MPI_Comm_size(comm, &wsize);
+    if (rc != MPI_SUCCESS) {
+        ers = "MPI_Comm_size() failed";
+        qvi_test_panic("%s (rc=%d)", ers, rc);
+    }
+
+    rc = MPI_Comm_rank(comm, &wrank);
+    if (rc != MPI_SUCCESS) {
+        ers = "MPI_Comm_rank() failed";
+        qvi_test_panic("%s (rc=%d)", ers, rc);
+    }
+
+    qv_context_t *mpi_ctx;
+    rc = qv_mpi_context_create(comm, &mpi_ctx);
+    if (rc != QV_SUCCESS) {
+        ers = "qv_mpi_context_create() failed";
+        qvi_test_panic("%s (rc=%s)", ers, qv_strerr(rc));
+    }
+
+    qv_scope_t *mpi_scope;
+    rc = qv_scope_get(mpi_ctx, QV_SCOPE_JOB, &mpi_scope);
+    if (rc != QV_SUCCESS) {
+        ers = "qv_scope_get() failed";
+        qvi_test_panic("%s (rc=%s)", ers, qv_strerr(rc));
+    }
+    qvi_test_scope_report(mpi_ctx, mpi_scope, "mpi_job_scope");
+
+    rc = qv_scope_nobjs(mpi_ctx, mpi_scope, QV_HW_OBJ_NUMANODE, &n_numas);
+    if (rc != QV_SUCCESS) {
+        ers = "qv_scope_nobjs() failed";
+        qvi_test_panic("%s (rc=%s)", ers, qv_strerr(rc));
+    }
+    fprintf(stdout,"[%d] Number of NUMANodes in mpi_scope is %d\n", wrank, n_numas);
+
+    qv_scope_t *mpi_numa_scope;
+    rc = qv_scope_split_at(mpi_ctx, mpi_scope, QV_HW_OBJ_NUMANODE, wrank % n_numas, &mpi_numa_scope);
+    if (rc != QV_SUCCESS) {
+        ers = "qv_scope_split_at() failed";
+        qvi_test_panic("%s (rc=%s)", ers, qv_strerr(rc));
+    }
+    qvi_test_scope_report(mpi_ctx, mpi_numa_scope, "mpi_numa_scope");
+
+    qvi_test_bind_push(mpi_ctx, mpi_numa_scope);
+
+    rc = qv_scope_taskid(mpi_ctx, mpi_numa_scope, &my_numa_id);
+    if (rc != QV_SUCCESS) {
+        ers = "qv_scope_taskid() failed";
+        qvi_test_panic("%s (rc=%s)", ers, qv_strerr(rc));
+    }
+    fprintf(stdout,"[%d] NUMA id is %d\n", wrank, my_numa_id);
+
+    rc = qv_scope_nobjs(mpi_ctx, mpi_numa_scope, QV_HW_OBJ_CORE, &n_cores);
+    if (rc != QV_SUCCESS) {
+        ers = "qv_scope_nobjs() failed";
+        qvi_test_panic("%s (rc=%s)", ers, qv_strerr(rc));
+    }
+    fprintf(stdout,"[%d] Number of Cores in mpi_numa_scope is %d\n", wrank, n_cores);
+
+    rc = qv_scope_nobjs(mpi_ctx, mpi_numa_scope, QV_HW_OBJ_PU, &n_pus);
+    if (rc != QV_SUCCESS) {
+        ers = "qv_scope_nobjs() failed";
+        qvi_test_panic("%s (rc=%s)", ers, qv_strerr(rc));
+    }
+    fprintf(stdout,"[%d] Number of PUs in mpi_numa_scope is %d\n", wrank, n_pus);
+
+    int nthreads = 2*n_cores;
+    assert(nthreads <= n_pus);
+
+    fprintf(stdout,"[%d] Number of threads : %i\n", wrank, nthreads);
+
+    int colors[nthreads];
+    for(int i = 0 ; i < nthreads ; i++)
+        colors[i] = i%n_cores;
+
+    qv_scope_t **th_scopes = NULL;
+
+    rc = qv_thread_scope_split_at(mpi_ctx, mpi_numa_scope, QV_HW_OBJ_CORE, colors, nthreads, &th_scopes);
+    if (rc != QV_SUCCESS) {
+        ers = "qv_thread_scope_split_at() failed";
+        qvi_test_panic("%s (rc=%s)", ers, qv_strerr(rc));
+    }
+
+    assert(th_scopes);
+
+    pthread_t thid[nthreads];
+    pthread_attr_t *attr = NULL;
+
+    for(int i  = 0 ; i < nthreads; i ++){
+        //sleep(1);
+        if (qv_pthread_create(&thid[i], attr, thread_work, (void *)(mpi_ctx), mpi_ctx, th_scopes[i]) != 0) {
+            perror("pthread_create() error");
+            exit(1);
+        }
+    }
+
+    void *ret;
+    for(int i  = 0 ; i < nthreads; i ++){
+        if (pthread_join(thid[i], &ret) != 0) {
+            perror("pthread_create() error");
+            exit(3);
+        }
+        fprintf(stdout,"Thread finished with '%s'\n", (char *)ret);
+    }
+
+    fprintf(stdout,"===================== Coucou\n");
+
+    /* Clean up */
+    for(int i  = 0 ; i < nthreads; i ++){
+        rc = qv_scope_free(mpi_ctx, th_scopes[i]);
+        if (rc != QV_SUCCESS) {
+            ers = "qv_scope_free() failed";
+            qvi_test_panic("%s (rc=%s)", ers, qv_strerr(rc));
+        }
+    }
+    free(th_scopes);
+
+    fprintf(stdout,"===================== Coucou 2\n");
+
+    rc = qv_scope_free(mpi_ctx, mpi_numa_scope);
+    if (rc != QV_SUCCESS) {
+        ers = "qv_scope_free() failed";
+        qvi_test_panic("%s (rc=%s)", ers, qv_strerr(rc));
+    }
+
+    fprintf(stdout,"===================== Coucou 3\n");
+
+    rc = qv_scope_free(mpi_ctx, mpi_scope);
+    if (rc != QV_SUCCESS) {
+        ers = "qv_scope_free() failed";
+        qvi_test_panic("%s (rc=%s)", ers, qv_strerr(rc));
+    }
+
+    fprintf(stdout,"===================== Coucou 4\n");
+
+    MPI_Finalize();
+
+    return EXIT_SUCCESS;
+}
+
+/*
+ * vim: ft=cpp ts=4 sts=4 sw=4 expandtab
+ */


### PR DESCRIPTION
This PR demonstrates issue https://github.com/hpc/quo-vadis/issues/162

The program to test is `test-pthread-split`

My command line (with my Open MPI install) is :
`mpiexec --tag-output --report-bindings -np 1  -host localhost --map-by core:OVERSUBSCRIBE  --bind-to core   ./test-pthread-split`

And the current output is :
```
mpiexec --tag-output --report-bindings -np 1  -host localhost --map-by core:OVERSUBSCRIBE  --bind-to core   ./test-pthread-split 
[1,0]<stderr>: [Palamede:1091043] Rank 0 bound to package[0][core:0]
[1,0]<stdout>: # Starting Hybrid MPI + Pthreads test
[1,0]<stdout>: =================> mutex ctxt init done @0x75039481b780
[1,0]<stdout>: [1091048] mpi_job_scope taskid is 0
[1,0]<stdout>: [1091048] mpi_job_scope ntasks is 1
[1,0]<stdout>: [0] Number of NUMANodes in mpi_scope is 1
[1,0]<stdout>: [1091048] mpi_numa_scope taskid is 0
[1,0]<stdout>: [1091048] mpi_numa_scope ntasks is 1
[1,0]<stdout>: [1091048] Current cpubind before qv_bind_push() is 0,4
[1,0]<stdout>: [1091048] New cpubind after qv_bind_push() is 0-7
[1,0]<stdout>: [0] NUMA id is 0
[1,0]<stdout>: [0] Number of Cores in mpi_numa_scope is 4
[1,0]<stdout>: [0] Number of PUs in mpi_numa_scope is 8
[1,0]<stdout>: [0] Number of threads : 8
[1,0]<stdout>: Subscope[0] ptr  = 0x5c5fc05b76d0
[1,0]<stdout>: Subscope[1] ptr  = 0x5c5fc05b78e0
[1,0]<stdout>: Subscope[2] ptr  = 0x5c5fc05ba480
[1,0]<stdout>: Subscope[3] ptr  = 0x5c5fc05bc200
[1,0]<stdout>: Subscope[4] ptr  = 0x5c5fc05bdf80
[1,0]<stdout>: Subscope[5] ptr  = 0x5c5fc05bfd00
[1,0]<stdout>: Subscope[6] ptr  = 0x5c5fc05c1a80
[1,0]<stdout>: Subscope[7] ptr  = 0x5c5fc05c3800
[1,0]<stdout>: ================ lock taken @0x5c5fc0591ce8
[1,0]<stdout>: ================ lock freed @0x5c5fc0591ce8
[1,0]<stdout>: ================ lock taken @0x5c5fc0591ce8
[1,0]<stdout>: Thread running on 0,4
[1,0]<stderr>: [quo-vadis error at (qvi-rmi.cc::qvi_zerr_msg::101)] zmq_msg_send() failed with errno=156384763 (Unknown error 156384763)
[1,0]<stderr>: [quo-vadis error at (qvi-rmi.cc::qvi_zerr_msg::101)] zmq_msg_send() truncated with errno=156384763 (Unknown error 156384763)
[1,0]<stdout>: ================ lock freed @0x5c5fc0591ce8
[1,0]<stdout>: ==== Bind Push error 
[1,0]<stdout>: ================ lock taken @0x5c5fc0591ce8
[1,0]<stdout>: Thread finished with '(null)'
[1,0]<stdout>: Thread finished with '(null)'
[1,0]<stdout>: ================ lock freed @0x5c5fc0591ce8
[1,0]<stdout>: ================ lock taken @0x5c5fc0591ce8
[1,0]<stdout>: ================ lock freed @0x5c5fc0591ce8
[1,0]<stdout>: ==== Bind Push error 
[1,0]<stdout>: ================ lock taken @0x5c5fc0591ce8
[1,0]<stderr>: [quo-vadis error at (qvi-rmi.cc::qvi_zerr_msg::101)] zmq_msg_send() failed with errno=156384763 (Unknown error 156384763)
[1,0]<stderr>: [quo-vadis error at (qvi-rmi.cc::qvi_zerr_msg::101)] zmq_msg_send() truncated with errno=156384763 (Unknown error 156384763)
[1,0]<stderr>: [quo-vadis error at (qvi-rmi.cc::qvi_zerr_msg::101)] zmq_msg_send() failed with errno=156384763 (Unknown error 156384763)
[1,0]<stderr>: [quo-vadis error at (qvi-rmi.cc::qvi_zerr_msg::101)] zmq_msg_send() truncated with errno=156384763 (Unknown error 156384763)
[1,0]<stdout>: Thread running on 2,6
[1,0]<stdout>: ================ lock taken @0x5c5fc0591ce8
[1,0]<stdout>: Thread finished with '(null)'
[1,0]<stdout>: Thread finished with '(null)'
[1,0]<stdout>: ================ lock freed @0x5c5fc0591ce8
[1,0]<stdout>: ==== Bind Push error 
[1,0]<stdout>: Thread finished with '(null)'
[1,0]<stdout>: ================ lock freed @0x5c5fc0591ce8
[1,0]<stdout>: ================ lock taken @0x5c5fc0591ce8
[1,0]<stderr>: [quo-vadis error at (qvi-rmi.cc::qvi_zerr_msg::101)] zmq_msg_send() failed with errno=156384763 (Unknown error 156384763)
[1,0]<stderr>: [quo-vadis error at (qvi-rmi.cc::qvi_zerr_msg::101)] zmq_msg_send() truncated with errno=156384763 (Unknown error 156384763)
[1,0]<stdout>: ================ lock freed @0x5c5fc0591ce8
[1,0]<stdout>: ==== Bind Push error 
[1,0]<stdout>: ================ lock taken @0x5c5fc0591ce8
[1,0]<stdout>: ================ lock freed @0x5c5fc0591ce8
[1,0]<stdout>: ==== Bind Push error 
[1,0]<stderr>: [quo-vadis error at (qvi-rmi.cc::qvi_zerr_msg::101)] zmq_msg_send() failed with errno=156384763 (Unknown error 156384763)
[1,0]<stderr>: [quo-vadis error at (qvi-rmi.cc::qvi_zerr_msg::101)] zmq_msg_send() truncated with errno=156384763 (Unknown error 156384763)
[1,0]<stdout>: Thread running on 1,5
[1,0]<stdout>: Thread finished with '(null)'
[1,0]<stdout>: Thread finished with '(null)'
[1,0]<stdout>: Thread finished with '(null)'
[1,0]<stdout>: ===================== Coucou
[1,0]<stdout>: ===================== Coucou 2
[1,0]<stdout>: ===================== Coucou 3
[1,0]<stdout>: ===================== Coucou 4
```
When uncommenting the call to `sleep` in the program, the output then becomes:
```
[1,0]<stderr>: [Palamede:1112008] Rank 0 bound to package[0][core:0]
[1,0]<stdout>: # Starting Hybrid MPI + Pthreads test
[1,0]<stdout>: =================> mutex ctxt init done @0x71e92941b780
[1,0]<stdout>: [1112011] mpi_job_scope taskid is 0
[1,0]<stdout>: [1112011] mpi_job_scope ntasks is 1
[1,0]<stdout>: [0] Number of NUMANodes in mpi_scope is 1
[1,0]<stdout>: [1112011] mpi_numa_scope taskid is 0
[1,0]<stdout>: [1112011] mpi_numa_scope ntasks is 1
[1,0]<stdout>: [1112011] Current cpubind before qv_bind_push() is 0,4
[1,0]<stdout>: [1112011] New cpubind after qv_bind_push() is 0-7
[1,0]<stdout>: [0] NUMA id is 0
[1,0]<stdout>: [0] Number of Cores in mpi_numa_scope is 4
[1,0]<stdout>: [0] Number of PUs in mpi_numa_scope is 8
[1,0]<stdout>: [0] Number of threads : 8
[1,0]<stdout>: Subscope[0] ptr  = 0x5ae46b71f6d0
[1,0]<stdout>: Subscope[1] ptr  = 0x5ae46b71f8e0
[1,0]<stdout>: Subscope[2] ptr  = 0x5ae46b722480
[1,0]<stdout>: Subscope[3] ptr  = 0x5ae46b724200
[1,0]<stdout>: Subscope[4] ptr  = 0x5ae46b725f80
[1,0]<stdout>: Subscope[5] ptr  = 0x5ae46b727d00
[1,0]<stdout>: Subscope[6] ptr  = 0x5ae46b729a80
[1,0]<stdout>: Subscope[7] ptr  = 0x5ae46b72b800
[1,0]<stdout>: ================ lock taken @0x5ae46b6f9ce8
[1,0]<stdout>: ================ lock freed @0x5ae46b6f9ce8
[1,0]<stdout>: Thread running on 0,4
[1,0]<stdout>: ================ lock taken @0x5ae46b6f9ce8
[1,0]<stdout>: ================ lock freed @0x5ae46b6f9ce8
[1,0]<stdout>: Thread running on 1,5
[1,0]<stdout>: ================ lock taken @0x5ae46b6f9ce8
[1,0]<stdout>: ================ lock freed @0x5ae46b6f9ce8
[1,0]<stdout>: Thread running on 2,6
[1,0]<stdout>: ================ lock taken @0x5ae46b6f9ce8
[1,0]<stdout>: ================ lock freed @0x5ae46b6f9ce8
[1,0]<stdout>: Thread running on 3,7
[1,0]<stdout>: ================ lock taken @0x5ae46b6f9ce8
[1,0]<stdout>: ================ lock freed @0x5ae46b6f9ce8
[1,0]<stdout>: Thread running on 0,4
[1,0]<stdout>: ================ lock taken @0x5ae46b6f9ce8
[1,0]<stdout>: ================ lock freed @0x5ae46b6f9ce8
[1,0]<stdout>: Thread running on 1,5
[1,0]<stdout>: ================ lock taken @0x5ae46b6f9ce8
[1,0]<stdout>: ================ lock freed @0x5ae46b6f9ce8
[1,0]<stdout>: Thread running on 2,6
[1,0]<stdout>: Thread finished with '(null)'
[1,0]<stdout>: Thread finished with '(null)'
[1,0]<stdout>: Thread finished with '(null)'
[1,0]<stdout>: Thread finished with '(null)'
[1,0]<stdout>: ================ lock taken @0x5ae46b6f9ce8
[1,0]<stdout>: Thread finished with '(null)'
[1,0]<stdout>: Thread finished with '(null)'
[1,0]<stdout>: Thread finished with '(null)'
[1,0]<stdout>: ================ lock freed @0x5ae46b6f9ce8
[1,0]<stdout>: Thread running on 3,7
[1,0]<stdout>: Thread finished with '(null)'
[1,0]<stdout>: ===================== Coucou
[1,0]<stdout>: ===================== Coucou 2
[1,0]<stdout>: ===================== Coucou 3
[1,0]<stdout>: ===================== Coucou 4
```

