### PR TITLE
Provide safer accessors to raw bitmap data.

### DIFF
--- a/src/quo-vadis.cc
+++ b/src/quo-vadis.cc
@@ -45,7 +45,7 @@ qv_bind_push(
     try {
         std::lock_guard<std::mutex> guard(ctx->mutex);
         return qvi_bind_push(
-            ctx->bind_stack, qvi_scope_cpuset_get(scope).data
+            ctx->bind_stack, qvi_scope_cpuset_get(scope).cdata()
         );
     }
     qvi_catch_and_return();

--- a/src/qvi-bbuff-rmi.h
+++ b/src/qvi-bbuff-rmi.h
@@ -527,7 +527,7 @@ qvi_bbuff_rmi_pack_item(
     qvi_bbuff_t *buff,
     const qvi_hwloc_bitmap_s &bitmap
 ) {
-    return qvi_bbuff_rmi_pack_item_impl(buff, bitmap.data);
+    return qvi_bbuff_rmi_pack_item_impl(buff, bitmap.cdata());
 }
 
 /**
@@ -919,7 +919,7 @@ qvi_bbuff_rmi_unpack_item(
     );
     if (rc != QV_SUCCESS) return rc;
 
-    rc = qvi_hwloc_bitmap_copy(raw_cpuset, bitmap.data);
+    rc = bitmap.set(raw_cpuset);
     qvi_hwloc_bitmap_free(&raw_cpuset);
     return rc;
 }

--- a/src/qvi-hwloc.cc
+++ b/src/qvi-hwloc.cc
@@ -1034,9 +1034,10 @@ get_nosdevs_in_cpuset(
 ) {
     int ndevs = 0;
     for (auto &dev : devs) {
-        if (hwloc_bitmap_isincluded(dev->affinity.data, cpuset)) ndevs++;
+        if (hwloc_bitmap_isincluded(dev->affinity.cdata(), cpuset)) ndevs++;
     }
     *nobjs = ndevs;
+
 
     return QV_SUCCESS;
 }
@@ -1154,7 +1155,7 @@ qvi_hwloc_devices_emit(
     }
     for (auto &dev : *devlist) {
         char *cpusets = nullptr;
-        int rc = qvi_hwloc_bitmap_asprintf(&cpusets, dev->affinity.data);
+        int rc = qvi_hwloc_bitmap_asprintf(&cpusets, dev->affinity.cdata());
         if (rc != QV_SUCCESS) return rc;
 
         qvi_log_info("  Device Name: {}", dev->name);
@@ -1177,7 +1178,7 @@ get_devices_in_cpuset_from_dev_list(
     qvi_hwloc_dev_list_t &devs
 ) {
     for (auto &dev : devlist) {
-        if (!hwloc_bitmap_isincluded(dev->affinity.data, cpuset)) continue;
+        if (!hwloc_bitmap_isincluded(dev->affinity.cdata(), cpuset)) continue;
 
         auto devin = std::make_shared<qvi_hwloc_device_t>();
         const int rc = qvi_hwloc_device_copy(dev.get(), devin.get());
@@ -1220,7 +1221,7 @@ qvi_hwloc_get_devices_in_bitmap(
     const qvi_hwloc_bitmap_s &bitmap,
     qvi_hwloc_dev_list_t &devs
 ) {
-    return get_devices_in_cpuset(hwl, dev_type, bitmap.data, devs);
+    return get_devices_in_cpuset(hwl, dev_type, bitmap.cdata(), devs);
 }
 
 int
@@ -1413,7 +1414,7 @@ qvi_hwloc_get_device_affinity(
     // lists tend to be small, so just perform a linear search for the given ID.
     for (const auto &dev : *devlist) {
         if (dev->id != device_id) continue;
-        rc = qvi_hwloc_bitmap_dup(dev->affinity.data, &icpuset);
+        rc = qvi_hwloc_bitmap_dup(dev->affinity.cdata(), &icpuset);
         if (rc != QV_SUCCESS) goto out;
     }
     if (!icpuset) rc = QV_ERR_NOT_FOUND;

--- a/src/qvi-hwloc.h
+++ b/src/qvi-hwloc.h
@@ -413,18 +413,20 @@ qvi_hwloc_supported_devices(void);
  * hwloc bitmap object.
  */
 struct qvi_hwloc_bitmap_s {
+private:
     /** Internal bitmap. */
-    hwloc_bitmap_t data = nullptr;
+    hwloc_bitmap_t m_data = nullptr;
+public:
     /** Default constructor. */
     qvi_hwloc_bitmap_s(void)
     {
-        const int rc = qvi_hwloc_bitmap_calloc(&data);
+        const int rc = qvi_hwloc_bitmap_calloc(&m_data);
         if (rc != QV_SUCCESS) throw qvi_runtime_error();
     }
     /** Construct via hwloc_const_bitmap_t. */
     explicit qvi_hwloc_bitmap_s(hwloc_const_bitmap_t bitmap)
     {
-        int rc = qvi_hwloc_bitmap_calloc(&data);
+        int rc = qvi_hwloc_bitmap_calloc(&m_data);
         if (rc != QV_SUCCESS) throw qvi_runtime_error();
         rc = set(bitmap);
         if (rc != QV_SUCCESS) throw qvi_runtime_error();
@@ -432,28 +434,46 @@ struct qvi_hwloc_bitmap_s {
     /** Copy constructor. */
     qvi_hwloc_bitmap_s(const qvi_hwloc_bitmap_s &src)
     {
-        int rc = qvi_hwloc_bitmap_calloc(&data);
+        int rc = qvi_hwloc_bitmap_calloc(&m_data);
         if (rc != QV_SUCCESS) throw qvi_runtime_error();
-        rc = qvi_hwloc_bitmap_copy(src.data, data);
+        rc = qvi_hwloc_bitmap_copy(src.m_data, m_data);
         if (rc != QV_SUCCESS) throw qvi_runtime_error();
     }
     /** Destructor. */
     ~qvi_hwloc_bitmap_s(void)
     {
-        qvi_hwloc_bitmap_free(&data);
+        qvi_hwloc_bitmap_free(&m_data);
     }
     /** Assignment operator. */
     void
     operator=(const qvi_hwloc_bitmap_s &src)
     {
-        const int rc = qvi_hwloc_bitmap_copy(src.data, data);
+        const int rc = qvi_hwloc_bitmap_copy(src.m_data, m_data);
         if (rc != QV_SUCCESS) throw qvi_runtime_error();
     }
     /** Sets the object's internal bitmap to match src's. */
     int
     set(hwloc_const_bitmap_t src)
     {
-        return qvi_hwloc_bitmap_copy(src, data);
+        return qvi_hwloc_bitmap_copy(src, m_data);
+    }
+    /**
+     * Returns a hwloc_bitmap_t that allows
+     * modification of internal instance data.
+     */
+    hwloc_bitmap_t
+    data(void)
+    {
+        return m_data;
+    }
+    /**
+     * Returns a hwloc_const_bitmap_t that
+     * cannot modify internal instance data.
+     */
+    hwloc_const_bitmap_t
+    cdata(void) const
+    {
+        return m_data;
     }
 };
 

--- a/src/qvi-map.cc
+++ b/src/qvi-map.cc
@@ -240,7 +240,7 @@ qvi_map_calc_shaffinity(
     for (uint_t cid = 0; cid < ncon; ++cid) {
         for (uint_t rid = 0; rid < nres; ++rid) {
             const int intersects = hwloc_bitmap_intersects(
-                faffs.at(cid).data, tores.at(rid).data
+                faffs.at(cid).cdata(), tores.at(rid).cdata()
             );
             if (intersects) {
                 res_affinity_map[rid].insert(cid);
@@ -306,7 +306,7 @@ qvi_map_cpuset_at(
     const qvi_hwloc_cpusets_t &cpusets,
     uint_t fid
 ) {
-    return cpusets.at(map.at(fid)).data;
+    return cpusets.at(map.at(fid)).cdata();
 }
 
 std::vector<uint_t>

--- a/src/qvi-nvml.cc
+++ b/src/qvi-nvml.cc
@@ -36,7 +36,7 @@ qvi_hwloc_nvml_get_device_cpuset_by_pci_bus_id(
     if (!qvi_hwloc_topo_is_this_system(hwl)) {
         return qvi_hwloc_bitmap_copy(
             hwloc_topology_get_topology_cpuset(qvi_hwloc_topo_get(hwl)),
-            cpuset.data
+            cpuset.data()
         );
     }
     // This method should be called once before invoking any other methods in
@@ -55,7 +55,7 @@ qvi_hwloc_nvml_get_device_cpuset_by_pci_bus_id(
     }
 
     const int hwrc = hwloc_nvml_get_device_cpuset(
-        qvi_hwloc_topo_get(hwl), device, cpuset.data
+        qvi_hwloc_topo_get(hwl), device, cpuset.data()
     );
     if (hwrc != 0) {
         rc = QV_ERR_HWLOC;

--- a/src/qvi-rsmi.cc
+++ b/src/qvi-rsmi.cc
@@ -36,7 +36,7 @@ qvi_hwloc_rsmi_get_device_cpuset_by_device_id(
     if (!qvi_hwloc_topo_is_this_system(hwl)) {
         return qvi_hwloc_bitmap_copy(
             hwloc_topology_get_topology_cpuset(qvi_hwloc_topo_get(hwl)),
-            cpuset.data
+            cpuset.data()
         );
     }
     // Else get the real thing.
@@ -50,7 +50,7 @@ qvi_hwloc_rsmi_get_device_cpuset_by_device_id(
     }
 
     hrc = hwloc_rsmi_get_device_cpuset(
-        qvi_hwloc_topo_get(hwl), devid, cpuset.data
+        qvi_hwloc_topo_get(hwl), devid, cpuset.data()
     );
     if (hrc != 0) {
         rc = QV_ERR_HWLOC;

--- a/src/qvi-scope.cc
+++ b/src/qvi-scope.cc
@@ -199,7 +199,7 @@ get_nobjs_in_hwpool(
 ) {
     if (qvi_hwloc_obj_type_is_host_resource(obj)) {
         return qvi_rmi_get_nobjs_in_cpuset(
-            rmi, obj, hwpool->get_cpuset().data, n
+            rmi, obj, hwpool->get_cpuset().cdata(), n
         );
     }
     // TODO(skg) This should go through the RMI.
@@ -818,8 +818,8 @@ agg_split_cpuset(
     // algorithm.
     for (uint_t chunkid = 0; chunkid < splitagg.split_size; ++chunkid) {
         rc = qvi_hwloc_split_cpuset_by_chunk_id(
-            hwloc, base_cpuset.data, splitagg.split_size,
-            chunkid, result[chunkid].data
+            hwloc, base_cpuset.cdata(), splitagg.split_size,
+            chunkid, result[chunkid].data()
         );
         if (rc != QV_SUCCESS) break;
     }
@@ -877,10 +877,7 @@ agg_split_get_new_osdev_cpusets(
         // Not the type we are looking to split.
         if (obj_type != dinfo.first) continue;
         // Copy the device's affinity to our list of device affinities.
-        rc = qvi_hwloc_bitmap_copy(
-            dinfo.second->affinity.data, result[affi++].data
-        );
-        if (rc != QV_SUCCESS) break;
+        result[affi++] = dinfo.second->affinity;
     }
     return rc;
 }
@@ -1258,7 +1255,7 @@ qvi_scope_create(
     // TODO(skg) We need to acquire these resources.
     int rc = qvi_rmi_get_cpuset_for_nobjs(
         parent->rmi,
-        parent->hwpool->get_cpuset().data,
+        parent->hwpool->get_cpuset().cdata(),
         type, nobjs, &cpuset
     );
     if (rc != QV_SUCCESS) goto out;


### PR DESCRIPTION
Provide two methods to gain access to internal bitmap data from a qvi_hwloc_bitmap_s. One provides read-only access (cdata()) and the other provides write access (data()). This prevents accidental overwriting of qvi_hwloc_bitmap_s data.