### PR TITLE
qv_thread_scope_split_* first implementation

### DIFF
--- a/src/qvi-bbuff-rmi.h
+++ b/src/qvi-bbuff-rmi.h
@@ -177,6 +177,15 @@ template<>
 inline void
 qvi_bbuff_rmi_pack_type_picture(
     std::string &picture,
+    qv_hw_obj_type_t *
+) {
+    picture += "i";
+}
+
+template<>
+inline void
+qvi_bbuff_rmi_pack_type_picture(
+    std::string &picture,
     qv_device_id_type_t
 ) {
     picture += "i";

--- a/src/qvi-hwloc.h
+++ b/src/qvi-hwloc.h
@@ -290,6 +290,17 @@ qvi_hwloc_get_nobjs_in_cpuset(
  *
  */
 int
+qvi_hwloc_get_obj_type_in_cpuset(
+    qvi_hwloc_t *hwl,
+    int npieces,
+    hwloc_const_cpuset_t cpuset,
+    qv_hw_obj_type_t *target_obj
+);    
+    
+/**
+ *
+ */
+int
 qvi_hwloc_obj_type_depth(
     qvi_hwloc_t *hwloc,
     qv_hw_obj_type_t type,

--- a/src/qvi-rmi.cc
+++ b/src/qvi-rmi.cc
@@ -67,6 +67,7 @@ typedef enum qvi_rpc_funid_e {
     FID_TASK_SET_CPUBIND_FROM_CPUSET,
     FID_OBJ_TYPE_DEPTH,
     FID_GET_NOBJS_IN_CPUSET,
+    FID_GET_OBJ_TYPE_IN_CPUSET,
     FID_GET_DEVICE_IN_CPUSET,
     FID_SCOPE_GET_INTRINSIC_HWPOOL
 } qvi_rpc_funid_t;
@@ -537,6 +538,32 @@ rpc_ssi_get_nobjs_in_cpuset(
     return qvrc;
 }
 
+
+static int
+rpc_ssi_get_obj_type_in_cpuset(
+    qvi_rmi_server_t *server,
+    qvi_msg_header_t *hdr,
+    void *input,
+    qvi_bbuff_t **output
+) {
+    int npieces = 0;    
+    hwloc_cpuset_t cpuset = nullptr;
+    int qvrc = qvi_bbuff_rmi_unpack(
+        input, &npieces, &cpuset
+    );
+    if (qvrc != QV_SUCCESS) return qvrc;
+
+    qv_hw_obj_type_t target_obj;    
+    const int rpcrc = qvi_hwloc_get_obj_type_in_cpuset(
+        server->config.hwloc, npieces, cpuset, &target_obj
+    );
+
+    qvrc = rpc_pack(output, hdr->fid, rpcrc, target_obj);
+
+    hwloc_bitmap_free(cpuset);
+    return qvrc;
+}
+
 static int
 rpc_ssi_get_device_in_cpuset(
     qvi_rmi_server_t *server,
@@ -657,6 +684,7 @@ static const qvi_rpc_fun_ptr_t rpc_dispatch_table[] = {
     rpc_ssi_task_set_cpubind_from_cpuset,
     rpc_ssi_obj_type_depth,
     rpc_ssi_get_nobjs_in_cpuset,
+    rpc_ssi_get_obj_type_in_cpuset,
     rpc_ssi_get_device_in_cpuset,
     rpc_ssi_scope_get_intrinsic_hwpool
 };
@@ -1103,6 +1131,30 @@ qvi_rmi_get_nobjs_in_cpuset(
 
     return rpcrc;
 }
+
+int
+qvi_rmi_get_obj_type_in_cpuset(
+    qvi_rmi_client_t *client,
+    int npieces,
+    hwloc_const_cpuset_t cpuset,
+    qv_hw_obj_type_t *target_obj
+) {
+    int qvrc = rpc_req(
+        client->zsock,
+        FID_GET_OBJ_TYPE_IN_CPUSET,
+        npieces,
+        cpuset
+    );
+    if (qvrc != QV_SUCCESS) return qvrc;
+
+    // Should be set by rpc_rep, so assume an error.
+    int rpcrc = QV_ERR_MSG;
+    qvrc = rpc_rep(client->zsock, &rpcrc, target_obj);
+    if (qvrc != QV_SUCCESS) return qvrc;
+
+    return rpcrc;
+}
+
 
 int
 qvi_rmi_get_device_in_cpuset(

--- a/src/qvi-rmi.h
+++ b/src/qvi-rmi.h
@@ -154,6 +154,20 @@ qvi_rmi_get_nobjs_in_cpuset(
     int *nobjs
 );
 
+
+/**
+ *
+ */
+int
+qvi_rmi_get_obj_type_in_cpuset(
+    qvi_rmi_client_t *client,
+    int npieces,
+    hwloc_const_cpuset_t cpuset,
+    qv_hw_obj_type_t *target_obj
+);
+
+
+    
 /**
  *
  */

--- a/src/qvi-scope.cc
+++ b/src/qvi-scope.cc
@@ -207,6 +207,20 @@ get_nobjs_in_hwpool(
     return QV_SUCCESS;
 }
 
+// This too
+static int
+get_obj_type_in_hwpool(
+    qvi_rmi_client_t *rmi,
+    qvi_hwpool_s *hwpool,
+    int npieces,
+    qv_hw_obj_type_t *obj
+) {
+    return qvi_rmi_get_obj_type_in_cpuset(
+       rmi, npieces, qvi_hwpool_cpuset_get(hwpool), obj
+    );  
+}
+
+
 template <typename TYPE>
 static int
 gather_values(
@@ -1124,6 +1138,7 @@ out:
     return rc;
 }
 
+
 int
 qvi_scope_ksplit(
     qv_scope_t *parent,
@@ -1303,6 +1318,17 @@ qvi_scope_nobjs(
     );
 }
 
+int
+qvi_scope_obj_type(
+    qv_scope_t *scope,
+    int npieces,
+    qv_hw_obj_type_t *obj
+) {
+    return get_obj_type_in_hwpool(
+       scope->rmi, scope->hwpool, npieces, obj
+    );
+}
+                   
 int
 qvi_scope_get_device_id(
     qv_scope_t *scope,

--- a/src/qvi-scope.h
+++ b/src/qvi-scope.h
@@ -170,6 +170,13 @@ qvi_scope_nobjs(
 );
 
 int
+qvi_scope_obj_type(
+    qv_scope_t *scope,
+    int npieces,
+    qv_hw_obj_type_t *obj
+); 
+
+int
 qvi_scope_get_device_id(
     qv_scope_t *scope,
     qv_hw_obj_type_t dev_obj,


### PR DESCRIPTION
First draft of implementation for `qv_thread_scope_split_*`.

Several questions/issues to discuss:

1. both routines do not use the `context` parameter? Is this an error on my side or should the interface be modified?
2. I question the behavior of the `qv_thread_scope_split` routine. This version is passing my simple test but I'm unsure that the result is what we want to achieve. To be discussed.
3. The thread bug with two threads being mapped to the same resources has still to be addressed.