### PR TITLE
Remove unneeded task type infrastructure.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -88,12 +88,6 @@ find_package(ZMQ REQUIRED)
 ################################################################################
 option(QV_MPI_SUPPORT "Toggle MPI support" ON)
 
-option(
-    QV_MPI_PROCESSES_ARE_THREADS
-    "Set to TRUE when the MPI library implements MPI processes as threads"
-    FALSE
-)
-
 message(CHECK_START "Determining MPI support status")
 if(QV_MPI_SUPPORT)
     message(CHECK_PASS "enabled")
@@ -114,15 +108,6 @@ if(QV_MPI_SUPPORT)
                 FATAL_ERROR
                 "Minimum MPI version not met: ${QV_MPI_VER} < ${QV_MPI_VER_MIN}"
             )
-        endif()
-        # By default we assume MPI processes are implemented as OS processes.
-        message(CHECK_START "Determining underlying MPI process type")
-        set(MPI_PROCESSES_ARE_THREADS FALSE)
-        if(QV_MPI_PROCESSES_ARE_THREADS)
-            set(MPI_PROCESSES_ARE_THREADS TRUE)
-            message(CHECK_PASS "threads")
-        else()
-            message(CHECK_PASS "OS processes")
         endif()
     endif()
 endif()

--- a/README.md
+++ b/README.md
@@ -31,7 +31,6 @@ cmake -DQV_GPU_SUPPORT=OFF -DQV_FORTRAN_SUPPORT=OFF ..
 | QV_GPU_SUPPORT               | ON      | Toggle GPU support                  |
 | QV_MPI_SUPPORT               | ON      | Toggle MPI support                  |
 | QV_OMP_SUPPORT               | ON      | Toggle OpenMP support               |
-| QV_MPI_PROCESSES_ARE_THREADS | FALSE   | Affirm MPI processes are threads    |
 
 
 ### Developer Build Options

--- a/config.h.in
+++ b/config.h.in
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2023 Triad National Security, LLC
+ * Copyright (c) 2020-2024 Triad National Security, LLC
  *                         All rights reserved.
  *
  * Copyright (c) 2020-2021 Lawrence Livermore National Security, LLC
@@ -35,10 +35,6 @@
 
 /** Set by find_package(MPI) */
 #cmakedefine MPI_FOUND
-/**
- * When defined assume that MPI processes are built atop threads, not OS processes.
- */
-#cmakedefine MPI_PROCESSES_ARE_THREADS
 /** Set by find_package(OpenMP) */
 #cmakedefine OPENMP_FOUND
 

--- a/src/qvi-bbuff-rmi.h
+++ b/src/qvi-bbuff-rmi.h
@@ -23,7 +23,6 @@
  * i = int
  * s = char *
  * s = std::string
- * t = qvi_task_id_t
  * z = qvi_bbuff_rmi_zero_msg_t
  */
 
@@ -201,24 +200,6 @@ qvi_bbuff_rmi_pack_type_picture(
     picture += "i";
 }
 
-template<>
-inline void
-qvi_bbuff_rmi_pack_type_picture(
-    std::string &picture,
-    qvi_task_type_t
-) {
-    picture += "i";
-}
-
-template<>
-inline void
-qvi_bbuff_rmi_pack_type_picture(
-    std::string &picture,
-    qvi_task_type_t *
-) {
-    picture += "i";
-}
-
 #if QVI_SIZEOF_INT != QVI_SIZEOF_PID_T
 template<>
 inline void
@@ -282,24 +263,6 @@ qvi_bbuff_rmi_pack_type_picture(
     qvi_bbuff_rmi_zero_msg_t
 ) {
     picture += "z";
-}
-
-template<>
-inline void
-qvi_bbuff_rmi_pack_type_picture(
-    std::string &picture,
-    qvi_task_id_t
-) {
-    picture += "t";
-}
-
-template<>
-inline void
-qvi_bbuff_rmi_pack_type_picture(
-    std::string &picture,
-    qvi_task_id_t *
-) {
-    picture += "t";
 }
 
 inline void
@@ -411,18 +374,6 @@ qvi_bbuff_rmi_pack_item(
     return qvi_bbuff_append(buff, &dai, sizeof(dai));
 }
 #endif
-
-/**
- * Packs qvi_task_type_t as an int.
- */
-inline int
-qvi_bbuff_rmi_pack_item(
-    qvi_bbuff_t *buff,
-    qvi_task_type_t data
-) {
-    const int dai = (int)data;
-    return qvi_bbuff_append(buff, &dai, sizeof(dai));
-}
 
 inline int
 qvi_bbuff_rmi_pack_item_impl(
@@ -618,21 +569,6 @@ qvi_bbuff_rmi_pack_item_impl(
 }
 
 /**
- * Packs qvi_task_id_t
- */
-inline int
-qvi_bbuff_rmi_pack_item_impl(
-    qvi_bbuff_t *buff,
-    qvi_task_id_t data
-) {
-    // Pack task type.
-    const int rc = qvi_bbuff_rmi_pack_item(buff, data.type);
-    if (rc != QV_SUCCESS) return rc;
-    // Pack pid
-    return qvi_bbuff_rmi_pack_item(buff, data.sid);
-}
-
-/**
  * Packs const qvi_hwpool_s *
  */
 inline int
@@ -650,17 +586,6 @@ inline int
 qvi_bbuff_rmi_pack_item(
     qvi_bbuff_t *buff,
     qvi_hwpool_s *data
-) {
-    return qvi_bbuff_rmi_pack_item_impl(buff, data);
-}
-
-/**
- * Packs qvi_task_id_t
- */
-inline int
-qvi_bbuff_rmi_pack_item(
-    qvi_bbuff_t *buff,
-    qvi_task_id_t data
 ) {
     return qvi_bbuff_rmi_pack_item_impl(buff, data);
 }
@@ -722,23 +647,6 @@ qvi_bbuff_rmi_unpack_item(
 ) {
     memmove(i, buffpos, sizeof(*i));
     *bytes_written = sizeof(*i);
-    return QV_SUCCESS;
-}
-
-/**
- * Unpacks qvi_task_type_t.
- */
-inline int
-qvi_bbuff_rmi_unpack_item(
-    qvi_task_type_t *o,
-    byte_t *buffpos,
-    size_t *bytes_written
-) {
-    // Remember we are sending this as an int.
-    int oai = 0;
-    memmove(&oai, buffpos, sizeof(oai));
-    *bytes_written = sizeof(oai);
-    *o = (qvi_task_type_t)oai;
     return QV_SUCCESS;
 }
 
@@ -1085,37 +993,6 @@ out:
     }
     *bytes_written = total_bw;
     *hwp = ihwp;
-    return rc;
-}
-
-/**
- * Unpacks qvi_task_id_t.
- */
-inline int
-qvi_bbuff_rmi_unpack_item(
-    qvi_task_id_t *taski,
-    byte_t *buffpos,
-    size_t *bytes_written
-) {
-    size_t bw = 0, total_bw = 0;
-
-    int rc = qvi_bbuff_rmi_unpack_item(
-        &taski->type, buffpos, &bw
-    );
-    if (rc != QV_SUCCESS) goto out;
-    total_bw += bw;
-    buffpos += bw;
-
-    rc = qvi_bbuff_rmi_unpack_item(
-        &taski->sid, buffpos, &bw
-    );
-    if (rc != QV_SUCCESS) goto out;
-    total_bw += bw;
-out:
-    if (rc != QV_SUCCESS) {
-        total_bw = 0;
-    }
-    *bytes_written = total_bw;
     return rc;
 }
 

--- a/src/qvi-hwloc.h
+++ b/src/qvi-hwloc.h
@@ -183,7 +183,7 @@ qvi_hwloc_get_nobjs_by_type(
 int
 qvi_hwloc_emit_cpubind(
    qvi_hwloc_t *hwl,
-   qvi_task_id_t task_id
+   pid_t task_id
 );
 
 /**
@@ -228,7 +228,7 @@ qvi_hwloc_bitmap_sscanf(
 int
 qvi_hwloc_task_get_cpubind(
     qvi_hwloc_t *hwl,
-    qvi_task_id_t task_id,
+    pid_t task_id,
     hwloc_cpuset_t *out_cpuset
 );
 
@@ -238,7 +238,7 @@ qvi_hwloc_task_get_cpubind(
 int
 qvi_hwloc_task_get_cpubind_as_string(
     qvi_hwloc_t *hwl,
-    qvi_task_id_t task_id,
+    pid_t task_id,
     char **cpusets
 );
 
@@ -249,7 +249,7 @@ int
 qvi_hwloc_task_intersects_obj_by_type_id(
     qvi_hwloc_t *hwl,
     qv_hw_obj_type_t type,
-    qvi_task_id_t task_id,
+    pid_t task_id,
     int type_index,
     int *result
 );
@@ -260,7 +260,7 @@ qvi_hwloc_task_intersects_obj_by_type_id(
 int
 qvi_hwloc_task_isincluded_in_obj_by_type_id(
     qvi_hwloc_t *hwl,
-    qvi_task_id_t task_id,
+    pid_t task_id,
     int type_index,
     int *result
 );
@@ -350,7 +350,7 @@ qvi_hwloc_device_copy(
 int
 qvi_hwloc_task_set_cpubind_from_cpuset(
     qvi_hwloc_t *hwl,
-    qvi_task_id_t task_id,
+    pid_t task_id,
     hwloc_const_cpuset_t cpuset
 );
 

--- a/src/qvi-mpi.cc
+++ b/src/qvi-mpi.cc
@@ -314,21 +314,6 @@ out:
     return rc;
 }
 
-/**
- * Returns the underlying representation of an MPI process.
- */
-#if 0
-static qvi_task_type_t
-get_mpi_process_type(void)
-{
-#ifdef MPI_PROCESSES_ARE_THREADS
-    return QVI_TASK_TYPE_THREAD;
-#else
-    return QVI_TASK_TYPE_PROCESS;
-#endif
-}
-#endif
-
 int
 qvi_mpi_init(
     qvi_mpi_t *mpi,

--- a/src/qvi-rmi.cc
+++ b/src/qvi-rmi.cc
@@ -457,7 +457,7 @@ rpc_ssi_task_get_cpubind(
     void *input,
     qvi_bbuff_t **output
 ) {
-    qvi_task_id_t who;
+    pid_t who;
     int qvrc = qvi_bbuff_rmi_unpack(input, &who);
     if (qvrc != QV_SUCCESS) return qvrc;
 
@@ -479,7 +479,7 @@ rpc_ssi_task_set_cpubind_from_cpuset(
     void *input,
     qvi_bbuff_t **output
 ) {
-    qvi_task_id_t who;
+    pid_t who;
     hwloc_cpuset_t cpuset = nullptr;
     const int qvrc = qvi_bbuff_rmi_unpack(input, &who, &cpuset);
     if (qvrc != QV_SUCCESS) return qvrc;
@@ -594,7 +594,7 @@ rpc_ssi_get_device_in_cpuset(
 static int
 get_intrinsic_scope_user(
     qvi_rmi_server_t *server,
-    qvi_task_id_t,
+    pid_t,
     qvi_hwpool_s **hwpool
 ) {
     // TODO(skg) Is the cpuset the best way to do this?
@@ -608,7 +608,7 @@ get_intrinsic_scope_user(
 static int
 get_intrinsic_scope_proc(
     qvi_rmi_server_t *server,
-    qvi_task_id_t who,
+    pid_t who,
     qvi_hwpool_s **hwpool
 ) {
     hwloc_cpuset_t cpuset = nullptr;
@@ -638,7 +638,7 @@ rpc_ssi_scope_get_intrinsic_hwpool(
 ) {
     // Get requestor task id (type and pid) and intrinsic scope as integers
     // from client request.
-    qvi_task_id_t requestor;
+    pid_t requestor;
     qv_scope_intrinsic_t iscope;
     int rc = qvi_bbuff_rmi_unpack(input, &requestor, &iscope);
     if (rc != QV_SUCCESS) return rc;
@@ -1015,7 +1015,7 @@ qvi_rmi_client_hwloc_get(
 int
 qvi_rmi_task_get_cpubind(
     qvi_rmi_client_t *client,
-    qvi_task_id_t who,
+    pid_t who,
     hwloc_cpuset_t *cpuset
 ) {
     int qvrc = rpc_req(
@@ -1040,7 +1040,7 @@ qvi_rmi_task_get_cpubind(
 int
 qvi_rmi_task_set_cpubind_from_cpuset(
     qvi_rmi_client_t *client,
-    qvi_task_id_t who,
+    pid_t who,
     hwloc_const_cpuset_t cpuset
 ) {
     int qvrc = rpc_req(
@@ -1062,7 +1062,7 @@ qvi_rmi_task_set_cpubind_from_cpuset(
 int
 qvi_rmi_scope_get_intrinsic_hwpool(
     qvi_rmi_client_t *client,
-    qvi_task_id_t who,
+    pid_t who,
     qv_scope_intrinsic_t iscope,
     qvi_hwpool_s **hwpool
 ) {

--- a/src/qvi-rmi.h
+++ b/src/qvi-rmi.h
@@ -107,7 +107,7 @@ qvi_rmi_client_hwloc_get(
 int
 qvi_rmi_task_get_cpubind(
     qvi_rmi_client_t *client,
-    qvi_task_id_t task_id,
+    pid_t task_id,
     hwloc_cpuset_t *cpuset
 );
 
@@ -117,7 +117,7 @@ qvi_rmi_task_get_cpubind(
 int
 qvi_rmi_task_set_cpubind_from_cpuset(
     qvi_rmi_client_t *client,
-    qvi_task_id_t task_id,
+    pid_t task_id,
     hwloc_const_cpuset_t cpuset
 );
 
@@ -127,7 +127,7 @@ qvi_rmi_task_set_cpubind_from_cpuset(
 int
 qvi_rmi_scope_get_intrinsic_hwpool(
     qvi_rmi_client_t *client,
-    qvi_task_id_t task_id,
+    pid_t task_id,
     qv_scope_intrinsic_t iscope,
     qvi_hwpool_s **hwpool
 );

--- a/src/qvi-scope.cc
+++ b/src/qvi-scope.cc
@@ -85,7 +85,7 @@ struct qvi_scope_split_agg_s {
      * index corresponds to a task ID. It is handy to have the task IDs for
      * splitting so we can query task characteristics during a splitting.
      */
-    std::vector<qvi_task_id_t> taskids{};
+    std::vector<pid_t> taskids{};
     /**
      * Vector of hardware pools, one for each member of the group. Note that the
      * number of hardware pools will always match the group size and that their
@@ -1146,7 +1146,7 @@ qvi_scope_ksplit(
     // Since this is called by a single task, get its ID and associated hardware
     // affinity here, and replicate them in the following loop that populates
     // splitagg. No point in doing this in a loop.
-    const qvi_task_id_t taskid = qvi_task_id();
+    const pid_t taskid = qvi_task_id();
     hwloc_cpuset_t task_affinity = nullptr;
     rc = qvi_rmi_task_get_cpubind(
         parent->rmi, taskid, &task_affinity

--- a/src/qvi-task.cc
+++ b/src/qvi-task.cc
@@ -25,11 +25,13 @@ struct qvi_task_s {
     qvi_rmi_client_t *rmi = nullptr;
     /** The task's bind stack. */
     qvi_task_bind_stack_t stack;
-
-    static qvi_task_id_t
+    /**
+     * Returns the caller's thread ID.
+     */
+    static pid_t
     me(void)
     {
-        return {QVI_TASK_TYPE_THREAD, qvi_gettid()};
+        return qvi_gettid();
     }
 
     int
@@ -158,7 +160,7 @@ qvi_task_rmi(
     return task->rmi;
 }
 
-qvi_task_id_t
+pid_t
 qvi_task_id(void)
 {
     return qvi_task_s::me();

--- a/src/qvi-task.h
+++ b/src/qvi-task.h
@@ -24,24 +24,6 @@ extern "C" {
 #endif
 
 /**
- * Supported task types.
- */
-typedef enum qvi_task_type_e {
-    QVI_TASK_TYPE_PROCESS = 0,
-    QVI_TASK_TYPE_THREAD
-} qvi_task_type_t;
-
-/**
- * Task identification.
- */
-typedef struct qvi_task_id_s {
-    /** Task type (OS process or OS thread). */
-    qvi_task_type_t type;
-    /** System ID: process or thread ID. */
-    pid_t sid;
-} qvi_task_id_t;
-
-/**
  *
  */
 int
@@ -59,7 +41,7 @@ qvi_task_rmi(
     qvi_task_t *task
 );
 
-qvi_task_id_t
+pid_t
 qvi_task_id(void);
 
 int

--- a/tests/internal/test-hwloc.c
+++ b/tests/internal/test-hwloc.c
@@ -1,6 +1,6 @@
 /* -*- Mode: C; c-basic-offset:4; indent-tabs-mode:nil -*- */
 /*
- * Copyright (c) 2020-2023 Triad National Security, LLC
+ * Copyright (c) 2020-2024 Triad National Security, LLC
  *                         All rights reserved.
  *
  * Copyright (c) 2020-2021 Lawrence Livermore National Security, LLC
@@ -14,8 +14,9 @@
  * @file test-hwloc.c
  */
 
-#include "qvi-macros.h"
+#include "qvi-common.h" // IWYU pragma: keep
 #include "qvi-hwloc.h"
+#include "qvi-utils.h"
 
 #include "quo-vadis.h"
 #include "qvi-test-common.h"
@@ -77,7 +78,7 @@ echo_task_intersections(
     char *bitmap_str
 ) {
     const int num_nts = sizeof(nts) / sizeof(hw_name_type_t);
-    const qvi_task_id_t me = {.type = QVI_TASK_TYPE_PROCESS, .sid = getpid()};
+    const pid_t me = qvi_gettid();
 
     printf("\n# Task Intersection Overview ------------\n");
     for (int i = 0; i < num_nts; ++i) {
@@ -161,10 +162,7 @@ main(void)
     char *binds = NULL;
     qvi_hwloc_t *hwl;
     hwloc_bitmap_t bitmap = NULL;
-    qvi_task_id_t who = {
-        .type = QVI_TASK_TYPE_PROCESS,
-        .sid = getpid()
-    };
+    pid_t who = qvi_gettid();
 
     int rc = qvi_hwloc_new(&hwl);
     if (rc != QV_SUCCESS) {

--- a/tests/internal/test-rmi.cc
+++ b/tests/internal/test-rmi.cc
@@ -102,7 +102,7 @@ client(
     printf("# [%d] Starting Client (%s)\n", getpid(), url);
 
     char const *ers = NULL;
-    qvi_task_id_t who = { QVI_TASK_TYPE_PROCESS, getpid() };
+    pid_t who = qvi_gettid();
     hwloc_bitmap_t bitmap = NULL;
 
     qvi_rmi_client_t *client = NULL;
@@ -125,7 +125,7 @@ client(
     }
     char *res;
     qvi_hwloc_bitmap_asprintf(&res, bitmap);
-    printf("# [%d] cpubind = %s\n", who.sid, res);
+    printf("# [%d] cpubind = %s\n", who, res);
     hwloc_bitmap_free(bitmap);
     free(res);
 out:


### PR DESCRIPTION
Since binding operations all now operate at the TID level, we no longer need the infrastructure to differentiate between processes and threads.