### PR TITLE
Rework scope bind string code with cleanups.

### DIFF
--- a/src/qvi-hwloc.h
+++ b/src/qvi-hwloc.h
@@ -18,7 +18,6 @@
 #define QVI_HWLOC_H
 
 #include "qvi-common.h"
-#include "qvi-task.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/src/qvi-rmi.h
+++ b/src/qvi-rmi.h
@@ -23,8 +23,6 @@
 #include "qvi-hwloc.h"
 #include "qvi-hwpool.h"
 
-// TODO(skg) Just pass a pointer to the task in the interfaces here.
-
 #ifdef __cplusplus
 
 struct qvi_rmi_config_s {

--- a/src/qvi-scope.cc
+++ b/src/qvi-scope.cc
@@ -1385,9 +1385,26 @@ qvi_scope_bind_string(
     qv_bind_string_format_t format,
     char **str
 ) {
-    return qvi_task_bind_string(
-        scope->group->task(), format, str
-    );
+    char *istr = nullptr;
+
+    hwloc_cpuset_t cpuset = nullptr;
+    int rc = qvi_task_bind_top(scope->group->task(), &cpuset);
+    if (rc != QV_SUCCESS) return rc;
+
+    switch (format) {
+        case QV_BIND_STRING_AS_BITMAP:
+            rc = qvi_hwloc_bitmap_asprintf(&istr, cpuset);
+            break;
+        case QV_BIND_STRING_AS_LIST:
+            rc = qvi_hwloc_bitmap_list_asprintf(&istr, cpuset);
+            break;
+        default:
+            rc = QV_ERR_INVLD_ARG;
+            break;
+    }
+    qvi_hwloc_bitmap_free(&cpuset);
+    *str = istr;
+    return rc;
 }
 
 /*

--- a/src/qvi-task.h
+++ b/src/qvi-task.h
@@ -23,9 +23,9 @@
 extern "C" {
 #endif
 
-/**
- *
- */
+pid_t
+qvi_task_id(void);
+
 int
 qvi_task_new(
     qvi_task_t **task
@@ -41,9 +41,6 @@ qvi_task_rmi(
     qvi_task_t *task
 );
 
-pid_t
-qvi_task_id(void);
-
 int
 qvi_task_bind_push(
     qvi_task_t *task,
@@ -56,10 +53,9 @@ qvi_task_bind_pop(
 );
 
 int
-qvi_task_bind_string(
+qvi_task_bind_top(
     qvi_task_t *task,
-    qv_bind_string_format_t format,
-    char **str
+    hwloc_cpuset_t *dest
 );
 
 #ifdef __cplusplus


### PR DESCRIPTION
The task should return the top of its bind stack. Move the generation of the bind string to the scope level.