### PR TITLE
Restructure OpenMP code, test nested parallelism.

### DIFF
--- a/src/qvi-thread.h
+++ b/src/qvi-thread.h
@@ -49,11 +49,6 @@ typedef struct qv_layout_s {
 } qv_layout_t;
 #endif
 
-int
-qvi_thread_group_new(
-    qvi_thread_group_t **group
-);
-
 void
 qvi_thread_group_free(
     qvi_thread_group_t **group

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -97,6 +97,7 @@ endif()
 if(MPI_FOUND)
     add_executable(
         test-mpi-init
+        qvi-test-common.h
         test-mpi-init.c
     )
 

--- a/tests/qvi-test-common.h
+++ b/tests/qvi-test-common.h
@@ -25,6 +25,7 @@
 #include <stdlib.h>
 #include <stdio.h>
 #include <string.h>
+#include <sys/syscall.h>
 #include <unistd.h>
 
 #define QVI_TEST_STRINGIFY(x) #x
@@ -42,6 +43,29 @@ do {                                                                           \
 // We assume that the quo-vadis.h is included before us.
 #ifdef QUO_VADIS
 
+static inline pid_t
+qvi_test_gettid(void)
+{
+    return (pid_t)syscall(SYS_gettid);
+}
+
+static inline void
+qvi_test_emit_task_bind(
+    qv_scope_t *scope
+) {
+    const int pid = qvi_test_gettid();
+    char const *ers = NULL;
+    // Get new, current binding.
+    char *binds = NULL;
+    int rc = qv_scope_bind_string(scope, QV_BIND_STRING_AS_LIST, &binds);
+    if (rc != QV_SUCCESS) {
+        ers = "qv_bind_string() failed";
+        qvi_test_panic("%s (rc=%s)", ers, qv_strerr(rc));
+    }
+    printf("[%d] cpubind=%s\n", pid, binds);
+    free(binds);
+}
+
 static inline void
 qvi_test_scope_report(
     qv_scope_t *scope,
@@ -49,7 +73,7 @@ qvi_test_scope_report(
 ) {
     char const *ers = NULL;
 
-    const int pid = getpid();
+    const int pid = qvi_test_gettid();
 
     int taskid;
     int rc = qv_scope_taskid(scope, &taskid);
@@ -87,8 +111,7 @@ qvi_test_bind_push(
     qv_scope_t *scope
 ) {
     char const *ers = NULL;
-
-    const int pid = getpid();
+    const int pid = qvi_test_gettid();
 
     int taskid;
     int rc = qv_scope_taskid(scope, &taskid);
@@ -143,7 +166,7 @@ qvi_test_bind_pop(
 ) {
     char const *ers = NULL;
 
-    const int pid = getpid();
+    const int pid = qvi_test_gettid();
 
     int taskid;
     int rc = qv_scope_taskid(scope, &taskid);
@@ -199,7 +222,7 @@ qvi_test_change_bind(
 ) {
     char const *ers = NULL;
 
-    const int pid = getpid();
+    const int pid = qvi_test_gettid();
 
     int taskid;
     int rc = qv_scope_taskid(scope, &taskid);

--- a/tests/test-threads.c
+++ b/tests/test-threads.c
@@ -8,11 +8,33 @@
 #include "quo-vadis-thread.h"
 #include <omp.h>
 
+static void
+emit_iter_info(
+    qv_scope_t *scope,
+    int i
+) {
+    char const *ers = NULL;
+    char *binds;
+    const int rc = qv_scope_bind_string(scope, QV_BIND_STRING_AS_LIST, &binds);
+    if (rc != QV_SUCCESS) {
+        ers = "qv_bind_string() failed";
+        qvi_test_panic("%s (rc=%s)", ers, qv_strerr(rc));
+    }
+    printf(
+        "[%d]: thread=%d of nthread=%d of thread=%d handling iter %d on %s\n",
+        qvi_test_gettid(), omp_get_thread_num(), omp_get_team_size(2),
+        omp_get_ancestor_thread_num(1), i, binds
+    );
+    free(binds);
+}
+
 int
 main(void)
 {
+    // Make sure nested parallism is on.
+    omp_set_nested(1);
 #pragma omp parallel
-#pragma omp single
+#pragma omp master
     printf("# Starting OpenMP Test (nthreads=%d)\n", omp_get_num_threads());
 
 #pragma omp parallel
@@ -36,8 +58,6 @@ main(void)
         qvi_test_panic("%s (rc=%s)", ers, qv_strerr(rc));
     }
 
-    qvi_test_scope_report(base_scope, "base_scope");
-#if 1
     qv_scope_t *sub_scope;
     rc = qv_scope_split(
         base_scope, 2, taskid, &sub_scope
@@ -47,14 +67,36 @@ main(void)
         qvi_test_panic("%s (rc=%s)", ers, qv_strerr(rc));
     }
 
-    qvi_test_scope_report(sub_scope, "sub_scope");
+    int nsubtasks = 0;
+    rc = qv_scope_ntasks(base_scope, &nsubtasks);
+    if (rc != QV_SUCCESS) {
+        ers = "qv_scope_ntasks() failed";
+        qvi_test_panic("%s (rc=%s)", ers, qv_strerr(rc));
+    }
+
+    qv_scope_bind_push(sub_scope);
+    #pragma omp task
+    #pragma omp parallel for num_threads(nsubtasks)
+    for (int i = 0; i < 8; ++i) {
+        emit_iter_info(sub_scope, i);
+    }
+    qv_scope_bind_pop(sub_scope);
+
+    qv_scope_bind_push(sub_scope);
+    #pragma omp task
+    #pragma omp parallel num_threads(1)
+    {
+        //qvi_test_emit_task_bind(sub_scope);
+    }
+    #pragma omp barrier
+    qv_scope_bind_pop(sub_scope);
 
     rc = qv_scope_free(sub_scope);
     if (rc != QV_SUCCESS) {
         ers = "qv_scope_free() failed";
         qvi_test_panic("%s (rc=%s)", ers, qv_strerr(rc));
     }
-#endif
+
     rc = qv_scope_free(base_scope);
     if (rc != QV_SUCCESS) {
         ers = "qv_scope_free() failed";


### PR DESCRIPTION
Commit a restructuring of the QV OpenMP code. The major difference is the removal of the shared data code, which was only used to house a pthread_barrier_t. My testing shows that the use of pthread_barrier_t in OpenMP regions may be unreliable.

Also commit a test of nested parallelism and how that might look using QV.