### PR TITLE
Remove task creation from the base group.

### DIFF
--- a/src/qvi-group-mpi.h
+++ b/src/qvi-group-mpi.h
@@ -22,16 +22,25 @@
 #include "qvi-mpi.h"
 
 struct qvi_group_mpi_s : public qvi_group_s {
+protected:
+    /** Task associated with this group. */
+    qvi_task_t *m_task = nullptr;
     /** Points to the base MPI context information. */
     qvi_mpi_t *mpi = nullptr;
     /** Underlying group instance. */
     qvi_mpi_group_t *mpi_group = nullptr;
+public:
     /** Default constructor. */
-    qvi_group_mpi_s(void) = default;
+    qvi_group_mpi_s(void)
+    {
+        const int rc = qvi_new(&m_task);
+        if (rc != QV_SUCCESS) throw qvi_runtime_error();
+    }
     /** Constructor. */
     qvi_group_mpi_s(
         qvi_mpi_t *mpi_ctx
-    ) {
+    ) : qvi_group_mpi_s()
+    {
         if (!mpi_ctx) throw qvi_runtime_error();
         mpi = mpi_ctx;
     }
@@ -39,6 +48,13 @@ struct qvi_group_mpi_s : public qvi_group_s {
     virtual ~qvi_group_mpi_s(void)
     {
         qvi_mpi_group_free(&mpi_group);
+        qvi_delete(&m_task);
+    }
+
+    virtual qvi_task_t *
+    task(void)
+    {
+        return m_task;
     }
 
     virtual int

--- a/src/qvi-group-omp.h
+++ b/src/qvi-group-omp.h
@@ -25,14 +25,29 @@
 #include "qvi-omp.h"
 
 struct qvi_group_omp_s : public qvi_group_s {
+protected:
+    /** Task associated with this group. */
+    qvi_task_t *m_task = nullptr;
     /** Underlying group instance. */
     qvi_omp_group_t *th_group = nullptr;
+public:
     /** Constructor. */
-    qvi_group_omp_s(void) = default;
+    qvi_group_omp_s(void)
+    {
+        const int rc = qvi_new(&m_task);
+        if (rc != QV_SUCCESS) throw qvi_runtime_error();
+    }
     /** Destructor. */
     virtual ~qvi_group_omp_s(void)
     {
         qvi_omp_group_free(&th_group);
+        qvi_delete(&m_task);
+    }
+
+    virtual qvi_task_t *
+    task(void)
+    {
+        return m_task;
     }
 
     virtual int

--- a/src/qvi-group-process.h
+++ b/src/qvi-group-process.h
@@ -19,14 +19,29 @@
 #include "qvi-process.h"
 
 struct qvi_group_process_s : public qvi_group_s {
+protected:
+    /** Task associated with this group. */
+    qvi_task_t *m_task = nullptr;
     /** Underlying group instance. */
     qvi_process_group_t *proc_group = nullptr;
+public:
     /** Constructor. */
-    qvi_group_process_s(void) = default;
+    qvi_group_process_s(void)
+    {
+        const int rc = qvi_new(&m_task);
+        if (rc != QV_SUCCESS) throw qvi_runtime_error();
+    }
     /** Destructor. */
     virtual ~qvi_group_process_s(void)
     {
         qvi_process_group_free(&proc_group);
+        qvi_delete(&m_task);
+    }
+
+    virtual qvi_task_t *
+    task(void)
+    {
+        return m_task;
     }
 
     virtual int

--- a/src/qvi-group.h
+++ b/src/qvi-group.h
@@ -28,28 +28,13 @@ using qvi_group_id_t = uint64_t;
  * Virtual base group class.
  */
 struct qvi_group_s : qvi_refc_s {
-protected:
-    // TODO(skg) Remove from base.
-    /** Task associated with this group. */
-    qvi_task_t *m_task = nullptr;
-public:
     /** Constructor. */
-    qvi_group_s(void)
-    {
-        const int rc = qvi_new(&m_task);
-        if (rc != QV_SUCCESS) throw qvi_runtime_error();
-    }
+    qvi_group_s(void) = default;
     /** Virtual destructor. */
-    virtual ~qvi_group_s(void)
-    {
-        qvi_delete(&m_task);
-    }
+    virtual ~qvi_group_s(void) = default;
     /** Returns pointer to the caller's task information. */
     virtual qvi_task_t *
-    task(void)
-    {
-        return m_task;
-    }
+    task(void) = 0;
     /** Returns the caller's group rank. */
     virtual int
     rank(void) = 0;

--- a/src/qvi-task.h
+++ b/src/qvi-task.h
@@ -38,7 +38,7 @@ public:
     /** Returns the caller's thread ID. */
     static pid_t
     mytid(void);
-    /** Default constructor. */
+    /** Constructor. */
     qvi_task_s(void);
     /** Copy constructor. */
     qvi_task_s(const qvi_task_s &src) = delete;


### PR DESCRIPTION
Most infrastructure requires a single base task during construction, but pthread infrastructure does not, so save a little memory by moving task creation into infrastructure-specific construction.