### PR TITLE
Rename test utility prefixes.

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,6 +1,6 @@
 # -*- Mode: C++; c-basic-offset:4; indent-tabs-mode:nil -*-
 #
-# Copyright (c) 2020-2024 Triad National Security, LLC
+# Copyright (c) 2020-2025 Triad National Security, LLC
 #                         All rights reserved.
 #
 # Copyright (c) 2020-2021 Lawrence Livermore National Security, LLC
@@ -82,7 +82,7 @@ endif()
 if(MPI_FOUND)
     add_executable(
         test-mpi-init
-        qvi-test-common.h
+        common-test-utils.h
         test-mpi-init.c
     )
 
@@ -144,7 +144,7 @@ if(MPI_FOUND)
 
     add_executable(
         test-pthread-split
-        qvi-test-common.h
+        common-test-utils.h
         test-pthread-split.c
     )
 

--- a/tests/common-test-utils.h
+++ b/tests/common-test-utils.h
@@ -1,6 +1,6 @@
 /* -*- Mode: C++; c-basic-offset:4; indent-tabs-mode:nil -*- */
 /*
- * Copyright (c) 2020-2023 Triad National Security, LLC
+ * Copyright (c) 2020-2025 Triad National Security, LLC
  *                         All rights reserved.
  *
  * This file is part of the quo-vadis project. See the LICENSE file at the
@@ -8,7 +8,7 @@
  */
 
 /**
- * @file qvi-test-common.h
+ * @file common-test-utils.h
  *
  * Common test infrastructure.
  */
@@ -28,10 +28,10 @@
 #include <sys/syscall.h>
 #include <unistd.h>
 
-#define QVI_TEST_STRINGIFY(x) #x
-#define QVI_TEST_TOSTRING(x)  QVI_TEST_STRINGIFY(x)
+#define CTU_STRINGIFY(x) #x
+#define CTU_TOSTRING(x)  CTU_STRINGIFY(x)
 
-#define qvi_test_panic(...)                                                    \
+#define ctu_panic(...)                                                         \
 do {                                                                           \
     fprintf(stderr, "\n%s@%d: ", __func__, __LINE__);                          \
     fprintf(stderr, __VA_ARGS__);                                              \
@@ -44,49 +44,49 @@ do {                                                                           \
 #ifdef QUO_VADIS
 
 static inline pid_t
-qvi_test_gettid(void)
+ctu_gettid(void)
 {
     return (pid_t)syscall(SYS_gettid);
 }
 
 static inline void
-qvi_test_emit_task_bind(
+ctu_emit_task_bind(
     qv_scope_t *scope
 ) {
-    const int pid = qvi_test_gettid();
+    const int pid = ctu_gettid();
     char const *ers = NULL;
     // Get new, current binding.
     char *binds = NULL;
     int rc = qv_scope_bind_string(scope, QV_BIND_STRING_AS_LIST, &binds);
     if (rc != QV_SUCCESS) {
         ers = "qv_bind_string() failed";
-        qvi_test_panic("%s (rc=%s)", ers, qv_strerr(rc));
+        ctu_panic("%s (rc=%s)", ers, qv_strerr(rc));
     }
     printf("[%d] cpubind=%s\n", pid, binds);
     free(binds);
 }
 
 static inline void
-qvi_test_scope_report(
+ctu_scope_report(
     qv_scope_t *scope,
     const char *const scope_name
 ) {
     char const *ers = NULL;
 
-    const int pid = qvi_test_gettid();
+    const int pid = ctu_gettid();
 
     int sgrank;
     int rc = qv_scope_group_rank(scope, &sgrank);
     if (rc != QV_SUCCESS) {
         ers = "qv_scope_group_rank() failed";
-        qvi_test_panic("%s (rc=%s)", ers, qv_strerr(rc));
+        ctu_panic("%s (rc=%s)", ers, qv_strerr(rc));
     }
 
     int sgsize;
     rc = qv_scope_group_size(scope, &sgsize);
     if (rc != QV_SUCCESS) {
         ers = "qv_scope_group_size() failed";
-        qvi_test_panic("%s (rc=%s)", ers, qv_strerr(rc));
+        ctu_panic("%s (rc=%s)", ers, qv_strerr(rc));
     }
 
     printf(
@@ -99,7 +99,7 @@ qvi_test_scope_report(
     rc = qv_scope_barrier(scope);
     if (rc != QV_SUCCESS) {
         ers = "qv_scope_barrier() failed";
-        qvi_test_panic("%s (rc=%s)", ers, qv_strerr(rc));
+        ctu_panic("%s (rc=%s)", ers, qv_strerr(rc));
     }
 }
 
@@ -107,24 +107,24 @@ qvi_test_scope_report(
  * A verbose version of qv_bind_push().
  */
 static inline void
-qvi_test_bind_push(
+ctu_bind_push(
     qv_scope_t *scope
 ) {
     char const *ers = NULL;
-    const int pid = qvi_test_gettid();
+    const int pid = ctu_gettid();
 
     int sgrank;
     int rc = qv_scope_group_rank(scope, &sgrank);
     if (rc != QV_SUCCESS) {
         ers = "qv_scope_group_rank() failed";
-        qvi_test_panic("%s (rc=%s)", ers, qv_strerr(rc));
+        ctu_panic("%s (rc=%s)", ers, qv_strerr(rc));
     }
     // Get current binding.
     char *bind0s;
     rc = qv_scope_bind_string(scope, QV_BIND_STRING_AS_LIST, &bind0s);
     if (rc != QV_SUCCESS) {
         ers = "qv_bind_string() failed";
-        qvi_test_panic("%s (rc=%s)", ers, qv_strerr(rc));
+        ctu_panic("%s (rc=%s)", ers, qv_strerr(rc));
     }
     printf("[%d] Current cpubind before qv_bind_push() is %s\n", pid, bind0s);
 
@@ -132,7 +132,7 @@ qvi_test_bind_push(
     rc = qv_scope_bind_push(scope);
     if (rc != QV_SUCCESS) {
         ers = "qv_bind_push() failed";
-        qvi_test_panic("%s (rc=%s)", ers, qv_strerr(rc));
+        ctu_panic("%s (rc=%s)", ers, qv_strerr(rc));
     }
 
     // Get new, current binding.
@@ -140,7 +140,7 @@ qvi_test_bind_push(
     rc = qv_scope_bind_string(scope, QV_BIND_STRING_AS_LIST, &bind1s);
     if (rc != QV_SUCCESS) {
         ers = "qv_bind_string() failed";
-        qvi_test_panic("%s (rc=%s)", ers, qv_strerr(rc));
+        ctu_panic("%s (rc=%s)", ers, qv_strerr(rc));
     }
     printf("[%d] New cpubind after qv_bind_push() is %s\n", pid, bind1s);
 
@@ -152,25 +152,25 @@ qvi_test_bind_push(
  * A verbose version of qv_bind_pop().
  */
 static inline void
-qvi_test_bind_pop(
+ctu_bind_pop(
     qv_scope_t *scope
 ) {
     char const *ers = NULL;
 
-    const int pid = qvi_test_gettid();
+    const int pid = ctu_gettid();
 
     int sgrank;
     int rc = qv_scope_group_rank(scope, &sgrank);
     if (rc != QV_SUCCESS) {
         ers = "qv_scope_group_rank() failed";
-        qvi_test_panic("%s (rc=%s)", ers, qv_strerr(rc));
+        ctu_panic("%s (rc=%s)", ers, qv_strerr(rc));
     }
     // Get current binding.
     char *bind0s;
     rc = qv_scope_bind_string(scope, QV_BIND_STRING_AS_LIST, &bind0s);
     if (rc != QV_SUCCESS) {
         ers = "qv_bind_string() failed";
-        qvi_test_panic("%s (rc=%s)", ers, qv_strerr(rc));
+        ctu_panic("%s (rc=%s)", ers, qv_strerr(rc));
     }
     printf("[%d] Current cpubind before qv_bind_pop() is %s\n", pid, bind0s);
 
@@ -178,14 +178,14 @@ qvi_test_bind_pop(
     rc = qv_scope_bind_pop(scope);
     if (rc != QV_SUCCESS) {
         ers = "qv_bind_push() failed";
-        qvi_test_panic("%s (rc=%s)", ers, qv_strerr(rc));
+        ctu_panic("%s (rc=%s)", ers, qv_strerr(rc));
     }
     // Get new, current binding.
     char *bind1s;
     rc = qv_scope_bind_string(scope, QV_BIND_STRING_AS_LIST, &bind1s);
     if (rc != QV_SUCCESS) {
         ers = "qv_bind_string() failed";
-        qvi_test_panic("%s (rc=%s)", ers, qv_strerr(rc));
+        ctu_panic("%s (rc=%s)", ers, qv_strerr(rc));
     }
     printf("[%d] New cpubind after qv_bind_pop() is %s\n", pid, bind1s);
 
@@ -198,25 +198,25 @@ qvi_test_bind_pop(
  * binding policies.
  */
 static inline void
-qvi_test_change_bind(
+ctu_change_bind(
     qv_scope_t *scope
 ) {
     char const *ers = NULL;
 
-    const int pid = qvi_test_gettid();
+    const int pid = ctu_gettid();
 
     int sgrank;
     int rc = qv_scope_group_rank(scope, &sgrank);
     if (rc != QV_SUCCESS) {
         ers = "qv_scope_group_rank() failed";
-        qvi_test_panic("%s (rc=%s)", ers, qv_strerr(rc));
+        ctu_panic("%s (rc=%s)", ers, qv_strerr(rc));
     }
     // Get current binding.
     char *bind0s;
     rc = qv_scope_bind_string(scope, QV_BIND_STRING_AS_LIST, &bind0s);
     if (rc != QV_SUCCESS) {
         ers = "qv_bind_string() failed";
-        qvi_test_panic("%s (rc=%s)", ers, qv_strerr(rc));
+        ctu_panic("%s (rc=%s)", ers, qv_strerr(rc));
     }
     printf("[%d] Current cpubind is %s\n", pid, bind0s);
 
@@ -224,7 +224,7 @@ qvi_test_change_bind(
     rc = qv_scope_bind_push(scope);
     if (rc != QV_SUCCESS) {
         ers = "qv_bind_push() failed";
-        qvi_test_panic("%s (rc=%s)", ers, qv_strerr(rc));
+        ctu_panic("%s (rc=%s)", ers, qv_strerr(rc));
     }
 
     // Get new, current binding.
@@ -232,27 +232,27 @@ qvi_test_change_bind(
     rc = qv_scope_bind_string(scope, QV_BIND_STRING_AS_LIST, &bind1s);
     if (rc != QV_SUCCESS) {
         ers = "qv_bind_string() failed";
-        qvi_test_panic("%s (rc=%s)", ers, qv_strerr(rc));
+        ctu_panic("%s (rc=%s)", ers, qv_strerr(rc));
     }
     printf("[%d] New cpubind is %s\n", pid, bind1s);
 
     rc = qv_scope_bind_pop(scope);
     if (rc != QV_SUCCESS) {
         ers = "qv_bind_pop() failed";
-        qvi_test_panic("%s (rc=%s)", ers, qv_strerr(rc));
+        ctu_panic("%s (rc=%s)", ers, qv_strerr(rc));
     }
 
     char *bind2s;
     rc = qv_scope_bind_string(scope, QV_BIND_STRING_AS_LIST, &bind2s);
     if (rc != QV_SUCCESS) {
         ers = "qv_bind_string() failed";
-        qvi_test_panic("%s (rc=%s)", ers, qv_strerr(rc));
+        ctu_panic("%s (rc=%s)", ers, qv_strerr(rc));
     }
     printf("[%d] Popped cpubind is %s\n", pid, bind2s);
 
     if (strcmp(bind0s, bind2s)) {
         ers = "bind push/pop mismatch";
-        qvi_test_panic("%s (rc=%s)", ers, qv_strerr(rc));
+        ctu_panic("%s (rc=%s)", ers, qv_strerr(rc));
     }
 
     free(bind0s);
@@ -262,7 +262,7 @@ qvi_test_change_bind(
     rc = qv_scope_barrier(scope);
     if (rc != QV_SUCCESS) {
         ers = "qv_scope_barrier() failed";
-        qvi_test_panic("%s (rc=%s)", ers, qv_strerr(rc));
+        ctu_panic("%s (rc=%s)", ers, qv_strerr(rc));
     }
 }
 

--- a/tests/internal/test-hwloc.c
+++ b/tests/internal/test-hwloc.c
@@ -19,7 +19,7 @@
 #include "qvi-utils.h"
 
 #include "quo-vadis.h"
-#include "qvi-test-common.h"
+#include "common-test-utils.h"
 
 typedef struct hw_name_type_s {
     char const *name;
@@ -27,16 +27,16 @@ typedef struct hw_name_type_s {
 } hw_name_type_t;
 
 static const hw_name_type_t nts[] = {
-    {QVI_TEST_TOSTRING(QV_HW_OBJ_MACHINE),  QV_HW_OBJ_MACHINE},
-    {QVI_TEST_TOSTRING(QV_HW_OBJ_PACKAGE),  QV_HW_OBJ_PACKAGE},
-    {QVI_TEST_TOSTRING(QV_HW_OBJ_CORE),     QV_HW_OBJ_CORE},
-    {QVI_TEST_TOSTRING(QV_HW_OBJ_PU),       QV_HW_OBJ_PU},
-    {QVI_TEST_TOSTRING(QV_HW_OBJ_L1CACHE),  QV_HW_OBJ_L1CACHE},
-    {QVI_TEST_TOSTRING(QV_HW_OBJ_L2CACHE),  QV_HW_OBJ_L2CACHE},
-    {QVI_TEST_TOSTRING(QV_HW_OBJ_L3CACHE),  QV_HW_OBJ_L3CACHE},
-    {QVI_TEST_TOSTRING(QV_HW_OBJ_L4CACHE),  QV_HW_OBJ_L4CACHE},
-    {QVI_TEST_TOSTRING(QV_HW_OBJ_L5CACHE),  QV_HW_OBJ_L5CACHE},
-    {QVI_TEST_TOSTRING(QV_HW_OBJ_NUMANODE), QV_HW_OBJ_NUMANODE}
+    {CTU_TOSTRING(QV_HW_OBJ_MACHINE),  QV_HW_OBJ_MACHINE},
+    {CTU_TOSTRING(QV_HW_OBJ_PACKAGE),  QV_HW_OBJ_PACKAGE},
+    {CTU_TOSTRING(QV_HW_OBJ_CORE),     QV_HW_OBJ_CORE},
+    {CTU_TOSTRING(QV_HW_OBJ_PU),       QV_HW_OBJ_PU},
+    {CTU_TOSTRING(QV_HW_OBJ_L1CACHE),  QV_HW_OBJ_L1CACHE},
+    {CTU_TOSTRING(QV_HW_OBJ_L2CACHE),  QV_HW_OBJ_L2CACHE},
+    {CTU_TOSTRING(QV_HW_OBJ_L3CACHE),  QV_HW_OBJ_L3CACHE},
+    {CTU_TOSTRING(QV_HW_OBJ_L4CACHE),  QV_HW_OBJ_L4CACHE},
+    {CTU_TOSTRING(QV_HW_OBJ_L5CACHE),  QV_HW_OBJ_L5CACHE},
+    {CTU_TOSTRING(QV_HW_OBJ_NUMANODE), QV_HW_OBJ_NUMANODE}
 };
 
 typedef struct device_name_type_s {
@@ -45,9 +45,9 @@ typedef struct device_name_type_s {
 } device_name_type_t;
 
 static const device_name_type_t devnts[] = {
-    {QVI_TEST_TOSTRING(QV_DEVICE_ID_UUID),       QV_DEVICE_ID_UUID},
-    {QVI_TEST_TOSTRING(QV_DEVICE_ID_PCI_BUS_ID), QV_DEVICE_ID_PCI_BUS_ID},
-    {QVI_TEST_TOSTRING(QV_DEVICE_ID_ORDINAL),    QV_DEVICE_ID_ORDINAL}
+    {CTU_TOSTRING(QV_DEVICE_ID_UUID),       QV_DEVICE_ID_UUID},
+    {CTU_TOSTRING(QV_DEVICE_ID_PCI_BUS_ID), QV_DEVICE_ID_PCI_BUS_ID},
+    {CTU_TOSTRING(QV_DEVICE_ID_ORDINAL),    QV_DEVICE_ID_ORDINAL}
 };
 
 static int
@@ -167,37 +167,37 @@ main(void)
     int rc = qvi_hwloc_new(&hwl);
     if (rc != QV_SUCCESS) {
         ers = "qvi_hwloc_new() failed";
-        qvi_test_panic("%s (rc=%s)", ers, qv_strerr(rc));
+        ctu_panic("%s (rc=%s)", ers, qv_strerr(rc));
     }
 
     rc = qvi_hwloc_topology_init(hwl, NULL);
     if (rc != QV_SUCCESS) {
         ers = "qvi_hwloc_topology_init() failed";
-        qvi_test_panic("%s (rc=%s)", ers, qv_strerr(rc));
+        ctu_panic("%s (rc=%s)", ers, qv_strerr(rc));
     }
 
     rc = qvi_hwloc_topology_load(hwl);
     if (rc != QV_SUCCESS) {
         ers = "qvi_hwloc_topology_load() failed";
-        qvi_test_panic("%s (rc=%s)", ers, qv_strerr(rc));
+        ctu_panic("%s (rc=%s)", ers, qv_strerr(rc));
     }
 
     rc = qvi_hwloc_discover_devices(hwl);
     if (rc != QV_SUCCESS) {
         ers = "qvi_hwloc_discover_devices() failed";
-        qvi_test_panic("%s (rc=%s)", ers, qv_strerr(rc));
+        ctu_panic("%s (rc=%s)", ers, qv_strerr(rc));
     }
 
     rc = echo_hw_info(hwl);
     if (rc != QV_SUCCESS) {
         ers = "echo_hw_info() failed";
-        qvi_test_panic("%s (rc=%s)", ers, qv_strerr(rc));
+        ctu_panic("%s (rc=%s)", ers, qv_strerr(rc));
     }
 
     rc = echo_gpu_info(hwl);
     if (rc != QV_SUCCESS) {
         ers = "echo_gpu_info() failed";
-        qvi_test_panic("%s (rc=%s)", ers, qv_strerr(rc));
+        ctu_panic("%s (rc=%s)", ers, qv_strerr(rc));
     }
 
     rc = qvi_hwloc_task_get_cpubind(
@@ -205,20 +205,20 @@ main(void)
     );
     if (rc != QV_SUCCESS) {
         ers = "qvi_hwloc_task_get_cpubind() failed";
-        qvi_test_panic("%s (rc=%s)", ers, qv_strerr(rc));
+        ctu_panic("%s (rc=%s)", ers, qv_strerr(rc));
     }
 
     rc = qvi_hwloc_bitmap_asprintf(bitmap, &binds);
     if (rc != QV_SUCCESS) {
         ers = "qvi_hwloc_bitmap_asprintf() failed";
-        qvi_test_panic("%s (rc=%s)", ers, qv_strerr(rc));
+        ctu_panic("%s (rc=%s)", ers, qv_strerr(rc));
     }
     printf("\n# cpuset=%s\n", binds);
 
     rc = echo_task_intersections(hwl, binds);
     if (rc != QV_SUCCESS) {
         ers = "echo_task_intersections() failed";
-        qvi_test_panic("%s (rc=%s)", ers, qv_strerr(rc));
+        ctu_panic("%s (rc=%s)", ers, qv_strerr(rc));
     }
 
     if (binds) free(binds);

--- a/tests/internal/test-rmi-server.cc
+++ b/tests/internal/test-rmi-server.cc
@@ -19,7 +19,7 @@
 #include "qvi-utils.h"
 #include "qvi-hwloc.h"
 #include "qvi-rmi.h"
-#include "qvi-test-common.h" // IWYU pragma: keep
+#include "common-test-utils.h" // IWYU pragma: keep
 
 static int
 server(

--- a/tests/test-mpi-api.c
+++ b/tests/test-mpi-api.c
@@ -12,7 +12,7 @@
  */
 
 #include "quo-vadis-mpi.h"
-#include "qvi-test-common.h"
+#include "common-test-utils.h"
 
 int
 main(
@@ -25,28 +25,28 @@ main(
     int rc = MPI_Init(&argc, &argv);
     if (rc != MPI_SUCCESS) {
         ers = "MPI_Init() failed";
-        qvi_test_panic("%s (rc=%d)", ers, rc);
+        ctu_panic("%s (rc=%d)", ers, rc);
     }
 
     int wsize = 0;
     rc = MPI_Comm_size(comm, &wsize);
     if (rc != MPI_SUCCESS) {
         ers = "MPI_Comm_size() failed";
-        qvi_test_panic("%s (rc=%d)", ers, rc);
+        ctu_panic("%s (rc=%d)", ers, rc);
     }
 
     int wrank = 0;
     rc = MPI_Comm_rank(comm, &wrank);
     if (rc != MPI_SUCCESS) {
         ers = "MPI_Comm_rank() failed";
-        qvi_test_panic("%s (rc=%d)", ers, rc);
+        ctu_panic("%s (rc=%d)", ers, rc);
     }
 
     int vmajor, vminor, vpatch;
     rc = qv_version(&vmajor, &vminor, &vpatch);
     if (rc != QV_SUCCESS) {
         ers = "qv_version() failed";
-        qvi_test_panic("%s (rc=%s)", ers, qv_strerr(rc));
+        ctu_panic("%s (rc=%s)", ers, qv_strerr(rc));
     }
 
     if (wrank == 0) {
@@ -59,38 +59,38 @@ main(
     );
     if (rc != QV_SUCCESS) {
         ers = "qv_mpi_scope_get() failed";
-        qvi_test_panic("%s (rc=%s)", ers, qv_strerr(rc));
+        ctu_panic("%s (rc=%s)", ers, qv_strerr(rc));
     }
 
     MPI_Comm wscope_comm = MPI_COMM_NULL;
     rc = qv_mpi_scope_comm_dup(world_scope, &wscope_comm);
     if (rc != QV_SUCCESS) {
         ers = "qv_mpi_scope_comm_dup() failed";
-        qvi_test_panic("%s (rc=%s)", ers, qv_strerr(rc));
+        ctu_panic("%s (rc=%s)", ers, qv_strerr(rc));
     }
 
     int wscope_size = 0;
     rc = MPI_Comm_size(wscope_comm, &wscope_size);
     if (rc != MPI_SUCCESS) {
         ers = "MPI_Comm_size() failed";
-        qvi_test_panic("%s (rc=%d)", ers, rc);
+        ctu_panic("%s (rc=%d)", ers, rc);
     }
 
     int wscope_rank = 0;
     rc = MPI_Comm_rank(wscope_comm, &wscope_rank);
     if (rc != MPI_SUCCESS) {
         ers = "MPI_Comm_rank() failed";
-        qvi_test_panic("%s (rc=%d)", ers, rc);
+        ctu_panic("%s (rc=%d)", ers, rc);
     }
 
     if (wscope_size != wsize) {
         ers = "MPI communicator size mismatch!";
-        qvi_test_panic("%s", ers);
+        ctu_panic("%s", ers);
     }
 
     if (wscope_rank != wrank) {
         ers = "MPI communicator rank mismatch!";
-        qvi_test_panic("%s", ers);
+        ctu_panic("%s", ers);
     }
 
     qv_scope_t *sub_scope = NULL;
@@ -99,21 +99,21 @@ main(
     );
     if (rc != QV_SUCCESS) {
         ers = "qv_scope_split() failed";
-        qvi_test_panic("%s (rc=%s)", ers, qv_strerr(rc));
+        ctu_panic("%s (rc=%s)", ers, qv_strerr(rc));
     }
 
     MPI_Comm split_wscope_comm = MPI_COMM_NULL;
     rc = qv_mpi_scope_comm_dup(sub_scope, &split_wscope_comm);
     if (rc != QV_SUCCESS) {
         ers = "qv_mpi_scope_comm_dup() failed";
-        qvi_test_panic("%s (rc=%s)", ers, qv_strerr(rc));
+        ctu_panic("%s (rc=%s)", ers, qv_strerr(rc));
     }
 
     int split_wscope_size = 0;
     rc = MPI_Comm_size(split_wscope_comm, &split_wscope_size);
     if (rc != MPI_SUCCESS) {
         ers = "MPI_Comm_size() failed";
-        qvi_test_panic("%s (rc=%d)", ers, rc);
+        ctu_panic("%s (rc=%d)", ers, rc);
     }
 
     if (wrank == 0) {
@@ -128,25 +128,25 @@ main(
     rc = qv_scope_free(sub_scope);
     if (rc != QV_SUCCESS) {
         ers = "qv_scope_free() failed";
-        qvi_test_panic("%s (rc=%s)", ers, qv_strerr(rc));
+        ctu_panic("%s (rc=%s)", ers, qv_strerr(rc));
     }
 
     rc = qv_scope_free(world_scope);
     if (rc != QV_SUCCESS) {
         ers = "qv_scope_free() failed";
-        qvi_test_panic("%s (rc=%s)", ers, qv_strerr(rc));
+        ctu_panic("%s (rc=%s)", ers, qv_strerr(rc));
     }
 
     rc = MPI_Comm_free(&wscope_comm);
     if (rc != MPI_SUCCESS) {
         ers = "MPI_Comm_free() failed";
-        qvi_test_panic("%s (rc=%d)", ers, rc);
+        ctu_panic("%s (rc=%d)", ers, rc);
     }
 
     rc = MPI_Comm_free(&split_wscope_comm);
     if (rc != MPI_SUCCESS) {
         ers = "MPI_Comm_free() failed";
-        qvi_test_panic("%s (rc=%d)", ers, rc);
+        ctu_panic("%s (rc=%d)", ers, rc);
     }
 
     if (wrank == 0) {

--- a/tests/test-mpi-getdev.c
+++ b/tests/test-mpi-getdev.c
@@ -1,6 +1,6 @@
 /* -*- Mode: C; c-basic-offset:4; indent-tabs-mode:nil -*- */
 #include "quo-vadis-mpi.h"
-#include "qvi-test-common.h"
+#include "common-test-utils.h"
 
 typedef struct device_name_type_s {
     char const *name;
@@ -8,9 +8,9 @@ typedef struct device_name_type_s {
 } device_name_type_t;
 
 static const device_name_type_t devnts[] = {
-    {QVI_TEST_TOSTRING(QV_DEVICE_ID_UUID),       QV_DEVICE_ID_UUID},
-    {QVI_TEST_TOSTRING(QV_DEVICE_ID_PCI_BUS_ID), QV_DEVICE_ID_PCI_BUS_ID},
-    {QVI_TEST_TOSTRING(QV_DEVICE_ID_ORDINAL),    QV_DEVICE_ID_ORDINAL}
+    {CTU_TOSTRING(QV_DEVICE_ID_UUID),       QV_DEVICE_ID_UUID},
+    {CTU_TOSTRING(QV_DEVICE_ID_PCI_BUS_ID), QV_DEVICE_ID_PCI_BUS_ID},
+    {CTU_TOSTRING(QV_DEVICE_ID_ORDINAL),    QV_DEVICE_ID_ORDINAL}
 };
 
 // TODO(skg) Merge with others
@@ -24,7 +24,7 @@ emit_gpu_info(
     int rc = qv_scope_nobjs(scope, QV_HW_OBJ_GPU, &ngpus);
     if (rc != QV_SUCCESS) {
         const char *ers = "qv_scope_nobjs() failed";
-        qvi_test_panic("%s (rc=%s)", ers, qv_strerr(rc));
+        ctu_panic("%s (rc=%s)", ers, qv_strerr(rc));
     }
 
     if (ngpus == 0) {
@@ -46,7 +46,7 @@ emit_gpu_info(
             );
             if (rc != QV_SUCCESS) {
                 const char *ers = "qv_scope_get_device_id() failed";
-                qvi_test_panic("%s (rc=%s)", ers, qv_strerr(rc));
+                ctu_panic("%s (rc=%s)", ers, qv_strerr(rc));
             }
             printf("# Device %u %s = %s\n", i, devnts[j].name, devids);
             free(devids);
@@ -66,21 +66,21 @@ main(
     int rc = MPI_Init(&argc, &argv);
     if (rc != MPI_SUCCESS) {
         ers = "MPI_Init() failed";
-        qvi_test_panic("%s (rc=%d)", ers, rc);
+        ctu_panic("%s (rc=%d)", ers, rc);
     }
 
     int wsize;
     rc = MPI_Comm_size(comm, &wsize);
     if (rc != MPI_SUCCESS) {
         ers = "MPI_Comm_size() failed";
-        qvi_test_panic("%s (rc=%d)", ers, rc);
+        ctu_panic("%s (rc=%d)", ers, rc);
     }
 
     int wrank;
     rc = MPI_Comm_rank(comm, &wrank);
     if (rc != MPI_SUCCESS) {
         ers = "MPI_Comm_rank() failed";
-        qvi_test_panic("%s (rc=%d)", ers, rc);
+        ctu_panic("%s (rc=%d)", ers, rc);
     }
 
     /* Get base scope: RM-given resources */
@@ -88,7 +88,7 @@ main(
     rc = qv_mpi_scope_get(comm, QV_SCOPE_USER, &base_scope);
     if (rc != QV_SUCCESS) {
         ers = "qv_mpi_scope_get() failed";
-        qvi_test_panic("%s (rc=%s)", ers, qv_strerr(rc));
+        ctu_panic("%s (rc=%s)", ers, qv_strerr(rc));
     }
 
     if (wrank == 0) {
@@ -100,7 +100,7 @@ main(
     rc = qv_scope_nobjs(base_scope, QV_HW_OBJ_GPU, &ngpus);
     if (rc != QV_SUCCESS) {
         ers = "qv_scope_nobjs() failed";
-        qvi_test_panic("%s (rc=%s)", ers, qv_strerr(rc));
+        ctu_panic("%s (rc=%s)", ers, qv_strerr(rc));
     }
     if (wrank == 0) {
         printf("[%d]: Base scope has %d GPUs\n", wrank, ngpus);
@@ -117,14 +117,14 @@ main(
     );
     if (rc != QV_SUCCESS) {
         ers = "qv_scope_split() failed";
-        qvi_test_panic("%s (rc=%s)", ers, qv_strerr(rc));
+        ctu_panic("%s (rc=%s)", ers, qv_strerr(rc));
     }
 
     /* Move to my subscope */
     rc = qv_scope_bind_push(rank_scope);
     if (rc != QV_SUCCESS) {
         ers = "qv_bind_push() failed";
-        qvi_test_panic("%s (rc=%s)", ers, qv_strerr(rc));
+        ctu_panic("%s (rc=%s)", ers, qv_strerr(rc));
     }
 
     /* Get num GPUs */
@@ -132,7 +132,7 @@ main(
     rc = qv_scope_nobjs(rank_scope, QV_HW_OBJ_GPU, &rank_ngpus);
     if (rc != QV_SUCCESS) {
         ers = "qv_scope_nobjs() failed";
-        qvi_test_panic("%s (rc=%s)", ers, qv_strerr(rc));
+        ctu_panic("%s (rc=%s)", ers, qv_strerr(rc));
     }
     printf("[%d]: Local scope has %d GPUs\n", wrank, rank_ngpus);
     // TODO(skg) Improve this test.

--- a/tests/test-mpi-init.c
+++ b/tests/test-mpi-init.c
@@ -15,7 +15,7 @@
  */
 
 #include "quo-vadis-mpi.h"
-#include "qvi-test-common.h"
+#include "common-test-utils.h"
 
 int
 main(
@@ -28,34 +28,34 @@ main(
     int rc = MPI_Init(&argc, &argv);
     if (rc != MPI_SUCCESS) {
         ers = "MPI_Init() failed";
-        qvi_test_panic("%s (rc=%d)", ers, rc);
+        ctu_panic("%s (rc=%d)", ers, rc);
     }
 
     int wsize;
     rc = MPI_Comm_size(comm, &wsize);
     if (rc != MPI_SUCCESS) {
         ers = "MPI_Comm_size() failed";
-        qvi_test_panic("%s (rc=%d)", ers, rc);
+        ctu_panic("%s (rc=%d)", ers, rc);
     }
 
     int wrank = 0;
     rc = MPI_Comm_rank(comm, &wrank);
     if (rc != MPI_SUCCESS) {
         ers = "MPI_Comm_rank() failed";
-        qvi_test_panic("%s (rc=%d)", ers, rc);
+        ctu_panic("%s (rc=%d)", ers, rc);
     }
 
     qv_scope_t *scope = NULL;
     rc = qv_mpi_scope_get(comm, QV_SCOPE_USER, &scope);
     if (rc != QV_SUCCESS) {
         ers = "qv_mpi_scope_get() failed";
-        qvi_test_panic("%s (rc=%s)", ers, qv_strerr(rc));
+        ctu_panic("%s (rc=%s)", ers, qv_strerr(rc));
     }
 
     rc = qv_scope_free(scope);
     if (rc != QV_SUCCESS) {
         ers = "qv_scope_free() failed";
-        qvi_test_panic("%s (rc=%s)", ers, qv_strerr(rc));
+        ctu_panic("%s (rc=%s)", ers, qv_strerr(rc));
     }
 
     MPI_Finalize();

--- a/tests/test-mpi-phases.c
+++ b/tests/test-mpi-phases.c
@@ -15,7 +15,7 @@
  */
 
 #include "quo-vadis-mpi.h"
-#include "qvi-test-common.h"
+#include "common-test-utils.h"
 
 #define USE_AFFINITY_PRESERVING 1
 
@@ -49,21 +49,21 @@ main(
     int rc = MPI_Init(&argc, &argv);
     if (rc != MPI_SUCCESS) {
         ers = "MPI_Init() failed";
-        qvi_test_panic("%s (rc=%d)", ers, rc);
+        ctu_panic("%s (rc=%d)", ers, rc);
     }
 
     int wsize;
     rc = MPI_Comm_size(comm, &wsize);
     if (rc != MPI_SUCCESS) {
         ers = "MPI_Comm_size() failed";
-        qvi_test_panic("%s (rc=%d)", ers, rc);
+        ctu_panic("%s (rc=%d)", ers, rc);
     }
 
     int wrank;
     rc = MPI_Comm_rank(comm, &wrank);
     if (rc != MPI_SUCCESS) {
         ers = "MPI_Comm_rank() failed";
-        qvi_test_panic("%s (rc=%d)", ers, rc);
+        ctu_panic("%s (rc=%d)", ers, rc);
     }
 
     setbuf(stdout, NULL);
@@ -77,7 +77,7 @@ main(
     );
     if (rc != QV_SUCCESS) {
         ers = "qv_mpi_scope_get() failed";
-        qvi_test_panic("%s (rc=%s)", ers, qv_strerr(rc));
+        ctu_panic("%s (rc=%s)", ers, qv_strerr(rc));
     }
 
     int ncores;
@@ -88,7 +88,7 @@ main(
     );
     if (rc != QV_SUCCESS) {
         ers = "qv_scope_nobjs() failed";
-        qvi_test_panic("%s (rc=%s)", ers, qv_strerr(rc));
+        ctu_panic("%s (rc=%s)", ers, qv_strerr(rc));
     }
 
     if (wrank == 0)
@@ -98,7 +98,7 @@ main(
     rc = qv_scope_bind_string(base_scope, QV_BIND_STRING_AS_LIST, &binds);
     if (rc != QV_SUCCESS) {
         ers = "qv_bind_get_list_as_string() failed";
-        qvi_test_panic("%s (rc=%s)", ers, qv_strerr(rc));
+        ctu_panic("%s (rc=%s)", ers, qv_strerr(rc));
     }
     printf("[%d] Base scope w/%d cores, running on %s\n",
        wrank, ncores, binds);
@@ -118,7 +118,7 @@ main(
     );
     if (rc != QV_SUCCESS) {
         ers = "qv_scope_split() failed";
-        qvi_test_panic("%s (rc=%s)", ers, qv_strerr(rc));
+        ctu_panic("%s (rc=%s)", ers, qv_strerr(rc));
     }
 
     /* What resources did I get? */
@@ -129,7 +129,7 @@ main(
     );
     if (rc != QV_SUCCESS) {
         ers = "qv_scope_nobjs() failed";
-        qvi_test_panic("%s (rc=%s)", ers, qv_strerr(rc));
+        ctu_panic("%s (rc=%s)", ers, qv_strerr(rc));
     }
 
     /***************************************
@@ -139,14 +139,14 @@ main(
     rc = qv_scope_bind_push(sub_scope);
     if (rc != QV_SUCCESS) {
         ers = "qv_bind_push() failed";
-        qvi_test_panic("%s (rc=%s)", ers, qv_strerr(rc));
+        ctu_panic("%s (rc=%s)", ers, qv_strerr(rc));
     }
 
     /* Where did I end up? */
     rc = qv_scope_bind_string(sub_scope, QV_BIND_STRING_AS_LIST, &binds);
     if (rc != QV_SUCCESS) {
         ers = "qv_bind_get_list_as_string() failed";
-        qvi_test_panic("%s (rc=%s)", ers, qv_strerr(rc));
+        ctu_panic("%s (rc=%s)", ers, qv_strerr(rc));
     }
     printf("=> [%d] Split: got %d cores, running on %s\n",
        wrank, ncores, binds);
@@ -165,7 +165,7 @@ main(
     );
     if (rc != QV_SUCCESS) {
         ers = "qv_scope_nobjs() failed";
-        qvi_test_panic("%s (rc=%s)", ers, qv_strerr(rc));
+        ctu_panic("%s (rc=%s)", ers, qv_strerr(rc));
     }
     printf("[%d] Launching %d GPU kernels\n", wrank, ngpus);
 
@@ -183,13 +183,13 @@ main(
     rc = qv_scope_bind_pop(sub_scope);
     if (rc != QV_SUCCESS) {
         ers = "qv_bind_pop() failed";
-        qvi_test_panic("%s (rc=%s)", ers, qv_strerr(rc));
+        ctu_panic("%s (rc=%s)", ers, qv_strerr(rc));
     }
 
     rc = qv_scope_bind_string(base_scope, QV_BIND_STRING_AS_LIST, &binds);
     if (rc != QV_SUCCESS) {
         ers = "qv_bind_get_list_as_string() failed";
-        qvi_test_panic("%s (rc=%s)", ers, qv_strerr(rc));
+        ctu_panic("%s (rc=%s)", ers, qv_strerr(rc));
     }
     printf("[%d] Popped up to %s\n", wrank, binds);
     free(binds);
@@ -198,7 +198,7 @@ main(
     rc = qv_scope_barrier(base_scope);
     if (rc != QV_SUCCESS) {
       ers = "qv_context_barrier() failed";
-      qvi_test_panic("%s (rc=%s)", ers, qv_strerr(rc));
+      ctu_panic("%s (rc=%s)", ers, qv_strerr(rc));
     }
 
     /***************************************
@@ -228,7 +228,7 @@ main(
     );
     if (rc != QV_SUCCESS) {
         ers = "qv_scope_nobjs() failed";
-        qvi_test_panic("%s (rc=%s)", ers, qv_strerr(rc));
+        ctu_panic("%s (rc=%s)", ers, qv_strerr(rc));
     }
 
     /* Split at NUMA domains */
@@ -244,7 +244,7 @@ main(
     );
     if (rc != QV_SUCCESS) {
         ers = "qv_scope_split_at() failed";
-        qvi_test_panic("%s (rc=%s)", ers, qv_strerr(rc));
+        ctu_panic("%s (rc=%s)", ers, qv_strerr(rc));
     }
 
     /* Allow selecting a leader per NUMA */
@@ -254,7 +254,7 @@ main(
     );
     if (rc != QV_SUCCESS) {
         ers = "qv_scope_group_rank() failed";
-        qvi_test_panic("%s (rc=%s)", ers, qv_strerr(rc));
+        ctu_panic("%s (rc=%s)", ers, qv_strerr(rc));
     }
 
     printf("[%d]: #NUMAs=%d numa_scope_id=%d\n",
@@ -263,7 +263,7 @@ main(
     rc = qv_scope_bind_push(numa_scope);
     if (rc != QV_SUCCESS) {
         ers = "qv_bind_push() failed";
-        qvi_test_panic("%s (rc=%s)", ers, qv_strerr(rc));
+        ctu_panic("%s (rc=%s)", ers, qv_strerr(rc));
     }
 
     int my_nnumas;
@@ -273,14 +273,14 @@ main(
             &my_nnumas);
     if (rc != QV_SUCCESS) {
         ers = "qv_scope_nobjs() failed";
-        qvi_test_panic("%s (rc=%s)", ers, qv_strerr(rc));
+        ctu_panic("%s (rc=%s)", ers, qv_strerr(rc));
     }
 
     /* Where did I end up? */
     rc = qv_scope_bind_string(numa_scope, QV_BIND_STRING_AS_LIST, &binds);
     if (rc != QV_SUCCESS) {
         ers = "qv_bind_get_list_as_string() failed";
-        qvi_test_panic("%s (rc=%s)", ers, qv_strerr(rc));
+        ctu_panic("%s (rc=%s)", ers, qv_strerr(rc));
     }
     printf("=> [%d] Split@NUMA: got %d NUMAs, running on %s\n",
        wrank, my_nnumas, binds);
@@ -297,7 +297,7 @@ main(
         );
         if (rc != QV_SUCCESS) {
             ers = "qv_scope_nobjs() failed";
-            qvi_test_panic("%s (rc=%s)", ers, qv_strerr(rc));
+            ctu_panic("%s (rc=%s)", ers, qv_strerr(rc));
         }
         printf("=> [%d] NUMA leader: Launching OMP region\n", wrank);
         do_omp_things(wrank, npus);
@@ -307,19 +307,19 @@ main(
     rc = qv_scope_barrier(numa_scope);
     if (rc != QV_SUCCESS) {
         ers = "qv_context_barrier() failed";
-        qvi_test_panic("%s (rc=%s)", ers, qv_strerr(rc));
+        ctu_panic("%s (rc=%s)", ers, qv_strerr(rc));
     }
 
     rc = qv_scope_bind_pop(numa_scope);
     if (rc != QV_SUCCESS) {
         ers = "qv_bind_pop() failed";
-        qvi_test_panic("%s (rc=%s)", ers, qv_strerr(rc));
+        ctu_panic("%s (rc=%s)", ers, qv_strerr(rc));
     }
 
     rc = qv_scope_bind_string(base_scope, QV_BIND_STRING_AS_LIST, &binds);
     if (rc != QV_SUCCESS) {
         ers = "qv_bind_get_list_as_string() failed";
-        qvi_test_panic("%s (rc=%s)", ers, qv_strerr(rc));
+        ctu_panic("%s (rc=%s)", ers, qv_strerr(rc));
     }
     printf("[%d] Popped up to %s\n", wrank, binds);
     free(binds);
@@ -328,7 +328,7 @@ main(
     rc = qv_scope_barrier(base_scope);
     if (rc != QV_SUCCESS) {
       ers = "qv_context_barrier() failed";
-      qvi_test_panic("%s (rc=%s)", ers, qv_strerr(rc));
+      ctu_panic("%s (rc=%s)", ers, qv_strerr(rc));
     }
 #endif
 
@@ -348,7 +348,7 @@ main(
             QV_HW_OBJ_GPU, &ngpus);
     if (rc != QV_SUCCESS) {
       ers = "qv_scope_nobjs() failed";
-      qvi_test_panic("%s (rc=%s)", ers, qv_strerr(rc));
+      ctu_panic("%s (rc=%s)", ers, qv_strerr(rc));
     }
 
     if (ngpus == 0) {
@@ -369,7 +369,7 @@ main(
     );
     if (rc != QV_SUCCESS) {
         ers = "qv_scope_split_at() failed";
-        qvi_test_panic("%s (rc=%s)", ers, qv_strerr(rc));
+        ctu_panic("%s (rc=%s)", ers, qv_strerr(rc));
     }
 
     /* Allow selecting a leader per NUMA */
@@ -379,13 +379,13 @@ main(
     );
     if (rc != QV_SUCCESS) {
         ers = "qv_scope_group_rank() failed";
-        qvi_test_panic("%s (rc=%s)", ers, qv_strerr(rc));
+        ctu_panic("%s (rc=%s)", ers, qv_strerr(rc));
     }
 
     rc = qv_scope_bind_push(gpu_scope);
     if (rc != QV_SUCCESS) {
         ers = "qv_bind_push() failed";
-        qvi_test_panic("%s (rc=%s)", ers, qv_strerr(rc));
+        ctu_panic("%s (rc=%s)", ers, qv_strerr(rc));
     }
 
     int my_ngpus;
@@ -395,14 +395,14 @@ main(
             &my_ngpus);
     if (rc != QV_SUCCESS) {
         ers = "qv_scope_nobjs() failed";
-        qvi_test_panic("%s (rc=%s)", ers, qv_strerr(rc));
+        ctu_panic("%s (rc=%s)", ers, qv_strerr(rc));
     }
 
     /* Where did I end up? */
     rc = qv_scope_bind_string(gpu_scope, QV_BIND_STRING_AS_LIST, &binds);
     if (rc != QV_SUCCESS) {
         ers = "qv_bind_get_list_as_string() failed";
-        qvi_test_panic("%s (rc=%s)", ers, qv_strerr(rc));
+        ctu_panic("%s (rc=%s)", ers, qv_strerr(rc));
     }
     printf("=> [%d] Split@GPU: got %d GPUs, running on %s\n",
        wrank, my_ngpus, binds);
@@ -421,26 +421,26 @@ main(
     rc = qv_scope_free(gpu_scope);
     if (rc != QV_SUCCESS) {
         ers = "qv_scope_free() failed";
-        qvi_test_panic("%s (rc=%s)", ers, qv_strerr(rc));
+        ctu_panic("%s (rc=%s)", ers, qv_strerr(rc));
     }
 
 done:
     rc = qv_scope_free(numa_scope);
     if (rc != QV_SUCCESS) {
         ers = "qv_scope_free() failed";
-        qvi_test_panic("%s (rc=%s)", ers, qv_strerr(rc));
+        ctu_panic("%s (rc=%s)", ers, qv_strerr(rc));
     }
 
     rc = qv_scope_free(sub_scope);
     if (rc != QV_SUCCESS) {
         ers = "qv_scope_free() failed";
-        qvi_test_panic("%s (rc=%s)", ers, qv_strerr(rc));
+        ctu_panic("%s (rc=%s)", ers, qv_strerr(rc));
     }
 
     rc = qv_scope_free(base_scope);
     if (rc != QV_SUCCESS) {
         ers = "qv_scope_free() failed";
-        qvi_test_panic("%s (rc=%s)", ers, qv_strerr(rc));
+        ctu_panic("%s (rc=%s)", ers, qv_strerr(rc));
     }
 
     MPI_Finalize();

--- a/tests/test-mpi-scope-create.c
+++ b/tests/test-mpi-scope-create.c
@@ -15,7 +15,7 @@
  */
 
 #include "quo-vadis-mpi.h"
-#include "qvi-test-common.h"
+#include "common-test-utils.h"
 
 #define USE_AFFINITY_PRESERVING 1
 
@@ -38,27 +38,27 @@ test_create_scope(
                ncores, 0, &core_scope);
   if (rc != QV_SUCCESS) {
     ers = "qv_scope_create() failed";
-    qvi_test_panic("%s (rc=%s)", ers, qv_strerr(rc));
+    ctu_panic("%s (rc=%s)", ers, qv_strerr(rc));
   }
 
   int res_ncores;
   rc = qv_scope_nobjs(core_scope, QV_HW_OBJ_CORE, &res_ncores);
   if (rc != QV_SUCCESS) {
     ers = "qv_scope_nobjs() failed";
-    qvi_test_panic("%s (rc=%s)", ers, qv_strerr(rc));
+    ctu_panic("%s (rc=%s)", ers, qv_strerr(rc));
   }
 
   rc = qv_scope_bind_push(core_scope);
   if (rc != QV_SUCCESS) {
     ers = "qv_bind_push() failed";
-    qvi_test_panic("%s (rc=%s)", ers, qv_strerr(rc));
+    ctu_panic("%s (rc=%s)", ers, qv_strerr(rc));
   }
 
   /* Where did I end up? */
   rc = qv_scope_bind_string(core_scope, QV_BIND_STRING_AS_LIST, &binds);
   if (rc != QV_SUCCESS) {
     ers = "qv_bind_get_list_as_string() failed";
-    qvi_test_panic("%s (rc=%s)", ers, qv_strerr(rc));
+    ctu_panic("%s (rc=%s)", ers, qv_strerr(rc));
   }
   printf("=> [%d] Core scope: got %d cores, running on %s\n",
      wrank, res_ncores, binds);
@@ -67,13 +67,13 @@ test_create_scope(
   rc = qv_scope_bind_pop(core_scope);
   if (rc != QV_SUCCESS) {
     ers = "qv_bind_pop() failed";
-    qvi_test_panic("%s (rc=%s)", ers, qv_strerr(rc));
+    ctu_panic("%s (rc=%s)", ers, qv_strerr(rc));
   }
 
   rc = qv_scope_bind_string(scope, QV_BIND_STRING_AS_LIST, &binds);
   if (rc != QV_SUCCESS) {
     ers = "qv_bind_get_list_as_string() failed";
-    qvi_test_panic("%s (rc=%s)", ers, qv_strerr(rc));
+    ctu_panic("%s (rc=%s)", ers, qv_strerr(rc));
   }
   printf("[%d] Popped up to %s\n", wrank, binds);
   free(binds);
@@ -82,7 +82,7 @@ test_create_scope(
     rc = qv_scope_free(core_scope);
     if (rc != QV_SUCCESS) {
       ers = "qv_scope_free() failed";
-      qvi_test_panic("%s (rc=%s)", ers, qv_strerr(rc));
+      ctu_panic("%s (rc=%s)", ers, qv_strerr(rc));
     }
   }
 
@@ -93,7 +93,7 @@ test_create_scope(
   rc = qv_context_barrier(ctx);
   if (rc != QV_SUCCESS) {
     ers = "qv_context_barrier() failed";
-    qvi_test_panic("%s (rc=%s)", ers, qv_strerr(rc));
+    ctu_panic("%s (rc=%s)", ers, qv_strerr(rc));
   }
 #endif
 }
@@ -110,21 +110,21 @@ main(
     int rc = MPI_Init(&argc, &argv);
     if (rc != MPI_SUCCESS) {
         ers = "MPI_Init() failed";
-        qvi_test_panic("%s (rc=%d)", ers, rc);
+        ctu_panic("%s (rc=%d)", ers, rc);
     }
 
     int wsize;
     rc = MPI_Comm_size(comm, &wsize);
     if (rc != MPI_SUCCESS) {
         ers = "MPI_Comm_size() failed";
-        qvi_test_panic("%s (rc=%d)", ers, rc);
+        ctu_panic("%s (rc=%d)", ers, rc);
     }
 
     int wrank;
     rc = MPI_Comm_rank(comm, &wrank);
     if (rc != MPI_SUCCESS) {
         ers = "MPI_Comm_rank() failed";
-        qvi_test_panic("%s (rc=%d)", ers, rc);
+        ctu_panic("%s (rc=%d)", ers, rc);
     }
 
     setbuf(stdout, NULL);
@@ -138,7 +138,7 @@ main(
     );
     if (rc != QV_SUCCESS) {
         ers = "qv_mpi_scope_get() failed";
-        qvi_test_panic("%s (rc=%s)", ers, qv_strerr(rc));
+        ctu_panic("%s (rc=%s)", ers, qv_strerr(rc));
     }
 
     int ncores;
@@ -149,14 +149,14 @@ main(
     );
     if (rc != QV_SUCCESS) {
         ers = "qv_scope_nobjs() failed";
-        qvi_test_panic("%s (rc=%s)", ers, qv_strerr(rc));
+        ctu_panic("%s (rc=%s)", ers, qv_strerr(rc));
     }
 
     char *binds;
     rc = qv_scope_bind_string(base_scope, QV_BIND_STRING_AS_LIST, &binds);
     if (rc != QV_SUCCESS) {
         ers = "qv_bind_get_list_as_string() failed";
-        qvi_test_panic("%s (rc=%s)", ers, qv_strerr(rc));
+        ctu_panic("%s (rc=%s)", ers, qv_strerr(rc));
     }
     printf("[%d] Base scope w/%d cores, running on %s\n",
        wrank, ncores, binds);
@@ -186,7 +186,7 @@ main(
     );
     if (rc != QV_SUCCESS) {
         ers = "qv_scope_split() failed";
-        qvi_test_panic("%s (rc=%s)", ers, qv_strerr(rc));
+        ctu_panic("%s (rc=%s)", ers, qv_strerr(rc));
     }
 
     /* What resources did I get? */
@@ -197,20 +197,20 @@ main(
     );
     if (rc != QV_SUCCESS) {
         ers = "qv_scope_nobjs() failed";
-        qvi_test_panic("%s (rc=%s)", ers, qv_strerr(rc));
+        ctu_panic("%s (rc=%s)", ers, qv_strerr(rc));
     }
 
     rc = qv_scope_bind_push(sub_scope);
     if (rc != QV_SUCCESS) {
         ers = "qv_bind_push() failed";
-        qvi_test_panic("%s (rc=%s)", ers, qv_strerr(rc));
+        ctu_panic("%s (rc=%s)", ers, qv_strerr(rc));
     }
 
     /* Where did I end up? */
     rc = qv_scope_bind_string(sub_scope, QV_BIND_STRING_AS_LIST, &binds);
     if (rc != QV_SUCCESS) {
         ers = "qv_bind_get_list_as_string() failed";
-        qvi_test_panic("%s (rc=%s)", ers, qv_strerr(rc));
+        ctu_panic("%s (rc=%s)", ers, qv_strerr(rc));
     }
     printf("=> [%d] Split: got %d cores, running on %s\n",
        wrank, ncores, binds);
@@ -245,13 +245,13 @@ main(
     rc = qv_scope_free(sub_scope);
     if (rc != QV_SUCCESS) {
         ers = "qv_scope_free() failed";
-        qvi_test_panic("%s (rc=%s)", ers, qv_strerr(rc));
+        ctu_panic("%s (rc=%s)", ers, qv_strerr(rc));
     }
 
     rc = qv_scope_free(base_scope);
     if (rc != QV_SUCCESS) {
         ers = "qv_scope_free() failed";
-        qvi_test_panic("%s (rc=%s)", ers, qv_strerr(rc));
+        ctu_panic("%s (rc=%s)", ers, qv_strerr(rc));
     }
 
     MPI_Finalize();

--- a/tests/test-mpi-scopes-affinity-preserving.c
+++ b/tests/test-mpi-scopes-affinity-preserving.c
@@ -12,7 +12,7 @@
  */
 
 #include "quo-vadis-mpi.h"
-#include "qvi-test-common.h"
+#include "common-test-utils.h"
 
 #include <signal.h>
 
@@ -27,7 +27,7 @@ main(
     int rc = MPI_Init(&argc, &argv);
     if (rc != MPI_SUCCESS) {
         ers = "MPI_Init() failed";
-        qvi_test_panic("%s (rc=%d)", ers, rc);
+        ctu_panic("%s (rc=%d)", ers, rc);
     }
 
     signal(SIGSEGV, SIG_DFL);
@@ -38,14 +38,14 @@ main(
     rc = MPI_Comm_size(comm, &wsize);
     if (rc != MPI_SUCCESS) {
         ers = "MPI_Comm_size() failed";
-        qvi_test_panic("%s (rc=%d)", ers, rc);
+        ctu_panic("%s (rc=%d)", ers, rc);
     }
 
     int wrank;
     rc = MPI_Comm_rank(comm, &wrank);
     if (rc != MPI_SUCCESS) {
         ers = "MPI_Comm_rank() failed";
-        qvi_test_panic("%s (rc=%d)", ers, rc);
+        ctu_panic("%s (rc=%d)", ers, rc);
     }
 
     qv_scope_t *base_scope;
@@ -56,10 +56,10 @@ main(
     );
     if (rc != QV_SUCCESS) {
         ers = "qv_mpi_scope_get() failed";
-        qvi_test_panic("%s (rc=%s)", ers, qv_strerr(rc));
+        ctu_panic("%s (rc=%s)", ers, qv_strerr(rc));
     }
 
-    qvi_test_scope_report(base_scope, "base_scope");
+    ctu_scope_report(base_scope, "base_scope");
 
     int base_scope_sgsize;
     rc = qv_scope_group_size(
@@ -68,7 +68,7 @@ main(
     );
     if (rc != QV_SUCCESS) {
         ers = "qv_scope_group_size() failed";
-        qvi_test_panic("%s (rc=%s)", ers, qv_strerr(rc));
+        ctu_panic("%s (rc=%s)", ers, qv_strerr(rc));
     }
 
     int base_scope_rank;
@@ -78,7 +78,7 @@ main(
     );
     if (rc != QV_SUCCESS) {
         ers = "qv_scope_group_rank() failed";
-        qvi_test_panic("%s (rc=%s)", ers, qv_strerr(rc));
+        ctu_panic("%s (rc=%s)", ers, qv_strerr(rc));
     }
 
     int n_pu;
@@ -89,7 +89,7 @@ main(
     );
     if (rc != QV_SUCCESS) {
         ers = "qv_scope_nobjs() failed";
-        qvi_test_panic("%s (rc=%s)", ers, qv_strerr(rc));
+        ctu_panic("%s (rc=%s)", ers, qv_strerr(rc));
     }
     printf("[%d] Number of PUs in base_scope is %d\n", wrank, n_pu);
 
@@ -103,32 +103,32 @@ main(
     );
     if (rc != QV_SUCCESS) {
         ers = "qv_scope_split() failed";
-        qvi_test_panic("%s (rc=%s)", ers, qv_strerr(rc));
+        ctu_panic("%s (rc=%s)", ers, qv_strerr(rc));
     }
 
-    qvi_test_scope_report(sub_scope, "sub_scope");
+    ctu_scope_report(sub_scope, "sub_scope");
 
-    qvi_test_change_bind(sub_scope);
+    ctu_change_bind(sub_scope);
 
     rc = qv_scope_nobjs(
         sub_scope, QV_HW_OBJ_PU, &n_pu
     );
     if (rc != QV_SUCCESS) {
         ers = "qv_scope_nobjs() failed";
-        qvi_test_panic("%s (rc=%s)", ers, qv_strerr(rc));
+        ctu_panic("%s (rc=%s)", ers, qv_strerr(rc));
     }
     printf("[%d] Number of PUs in sub_scope is %d\n", wrank, n_pu);
 
     rc = qv_scope_free(base_scope);
     if (rc != QV_SUCCESS) {
         ers = "qv_scope_free() failed";
-        qvi_test_panic("%s (rc=%s)", ers, qv_strerr(rc));
+        ctu_panic("%s (rc=%s)", ers, qv_strerr(rc));
     }
 
     rc = qv_scope_free(sub_scope);
     if (rc != QV_SUCCESS) {
         ers = "qv_scope_free() failed";
-        qvi_test_panic("%s (rc=%s)", ers, qv_strerr(rc));
+        ctu_panic("%s (rc=%s)", ers, qv_strerr(rc));
     }
 
     MPI_Finalize();

--- a/tests/test-mpi-scopes.c
+++ b/tests/test-mpi-scopes.c
@@ -15,7 +15,7 @@
  */
 
 #include "quo-vadis-mpi.h"
-#include "qvi-test-common.h"
+#include "common-test-utils.h"
 
 static int
 get_group_id(
@@ -24,7 +24,7 @@ get_group_id(
     int npieces
 ) {
     if (npieces != 2) {
-        qvi_test_panic("This test requires npieces=2");
+        ctu_panic("This test requires npieces=2");
     }
     const int nchunk = (ntask + (ntask % npieces)) / npieces;
     return taskid / nchunk;
@@ -41,21 +41,21 @@ main(
     int rc = MPI_Init(&argc, &argv);
     if (rc != MPI_SUCCESS) {
         ers = "MPI_Init() failed";
-        qvi_test_panic("%s (rc=%d)", ers, rc);
+        ctu_panic("%s (rc=%d)", ers, rc);
     }
 
     int wsize;
     rc = MPI_Comm_size(comm, &wsize);
     if (rc != MPI_SUCCESS) {
         ers = "MPI_Comm_size() failed";
-        qvi_test_panic("%s (rc=%d)", ers, rc);
+        ctu_panic("%s (rc=%d)", ers, rc);
     }
 
     int wrank;
     rc = MPI_Comm_rank(comm, &wrank);
     if (rc != MPI_SUCCESS) {
         ers = "MPI_Comm_rank() failed";
-        qvi_test_panic("%s (rc=%d)", ers, rc);
+        ctu_panic("%s (rc=%d)", ers, rc);
     }
 
     setbuf(stdout, NULL);
@@ -68,14 +68,14 @@ main(
     );
     if (rc != QV_SUCCESS) {
         ers = "qv_mpi_scope_get(QV_SCOPE_PROCESS) failed";
-        qvi_test_panic("%s (rc=%s)", ers, qv_strerr(rc));
+        ctu_panic("%s (rc=%s)", ers, qv_strerr(rc));
     }
-    qvi_test_scope_report(self_scope, "self_scope");
+    ctu_scope_report(self_scope, "self_scope");
 
     rc = qv_scope_free(self_scope);
     if (rc != QV_SUCCESS) {
         ers = "qv_scope_free() failed";
-        qvi_test_panic("%s (rc=%s)", ers, qv_strerr(rc));
+        ctu_panic("%s (rc=%s)", ers, qv_strerr(rc));
     }
 
     qv_scope_t *base_scope;
@@ -86,9 +86,9 @@ main(
     );
     if (rc != QV_SUCCESS) {
         ers = "qv_mpi_scope_get() failed";
-        qvi_test_panic("%s (rc=%s)", ers, qv_strerr(rc));
+        ctu_panic("%s (rc=%s)", ers, qv_strerr(rc));
     }
-    qvi_test_scope_report(base_scope, "base_scope");
+    ctu_scope_report(base_scope, "base_scope");
 
     int base_scope_sgsize;
     rc = qv_scope_group_size(
@@ -97,7 +97,7 @@ main(
     );
     if (rc != QV_SUCCESS) {
         ers = "qv_scope_group_size() failed";
-        qvi_test_panic("%s (rc=%s)", ers, qv_strerr(rc));
+        ctu_panic("%s (rc=%s)", ers, qv_strerr(rc));
     }
 
     int base_scope_rank;
@@ -107,7 +107,7 @@ main(
     );
     if (rc != QV_SUCCESS) {
         ers = "qv_scope_group_rank() failed";
-        qvi_test_panic("%s (rc=%s)", ers, qv_strerr(rc));
+        ctu_panic("%s (rc=%s)", ers, qv_strerr(rc));
     }
 
     int n_pu;
@@ -118,7 +118,7 @@ main(
     );
     if (rc != QV_SUCCESS) {
         ers = "qv_scope_nobjs() failed";
-        qvi_test_panic("%s (rc=%s)", ers, qv_strerr(rc));
+        ctu_panic("%s (rc=%s)", ers, qv_strerr(rc));
     }
     printf("[%d] Number of PUs in base_scope is %d\n", wrank, n_pu);
 
@@ -139,7 +139,7 @@ main(
     );
     if (rc != QV_SUCCESS) {
         ers = "qv_scope_split() failed";
-        qvi_test_panic("%s (rc=%s)", ers, qv_strerr(rc));
+        ctu_panic("%s (rc=%s)", ers, qv_strerr(rc));
     }
 
     rc = qv_scope_nobjs(
@@ -149,12 +149,12 @@ main(
     );
     if (rc != QV_SUCCESS) {
         ers = "qv_scope_nobjs() failed";
-        qvi_test_panic("%s (rc=%s)", ers, qv_strerr(rc));
+        ctu_panic("%s (rc=%s)", ers, qv_strerr(rc));
     }
     printf("[%d] Number of PUs in sub_scope is %d\n", wrank, n_pu);
 
-    qvi_test_scope_report(sub_scope, "sub_scope");
-    qvi_test_change_bind(sub_scope);
+    ctu_scope_report(sub_scope, "sub_scope");
+    ctu_change_bind(sub_scope);
 
     if (base_scope_rank == 0) {
         qv_scope_t *create_scope;
@@ -164,7 +164,7 @@ main(
         );
         if (rc != QV_SUCCESS) {
             ers = "qv_scope_create() failed";
-            qvi_test_panic("%s (rc=%s)", ers, qv_strerr(rc));
+            ctu_panic("%s (rc=%s)", ers, qv_strerr(rc));
         }
 
         int n_core;
@@ -175,18 +175,18 @@ main(
         );
         if (rc != QV_SUCCESS) {
             ers = "qv_scope_nobjs() failed";
-            qvi_test_panic("%s (rc=%s)", ers, qv_strerr(rc));
+            ctu_panic("%s (rc=%s)", ers, qv_strerr(rc));
         }
         printf("[%d] Number of PUs in create_scope is %d\n", wrank, n_core);
 
-        qvi_test_scope_report(create_scope, "create_scope");
+        ctu_scope_report(create_scope, "create_scope");
 
-        qvi_test_bind_push(create_scope);
+        ctu_bind_push(create_scope);
 
         rc = qv_scope_free(create_scope);
         if (rc != QV_SUCCESS) {
             ers = "qv_scope_free() failed";
-            qvi_test_panic("%s (rc=%s)", ers, qv_strerr(rc));
+            ctu_panic("%s (rc=%s)", ers, qv_strerr(rc));
         }
     }
 
@@ -199,7 +199,7 @@ main(
     );
     if (rc != QV_SUCCESS) {
         ers = "qv_scope_split() failed";
-        qvi_test_panic("%s (rc=%s)", ers, qv_strerr(rc));
+        ctu_panic("%s (rc=%s)", ers, qv_strerr(rc));
     }
 
     rc = qv_scope_nobjs(
@@ -209,26 +209,26 @@ main(
     );
     if (rc != QV_SUCCESS) {
         ers = "qv_scope_nobjs() failed";
-        qvi_test_panic("%s (rc=%s)", ers, qv_strerr(rc));
+        ctu_panic("%s (rc=%s)", ers, qv_strerr(rc));
     }
     printf("[%d] Number of PUs in sub_sub_scope is %d\n", wrank, n_pu);
 
     rc = qv_scope_free(base_scope);
     if (rc != QV_SUCCESS) {
         ers = "qv_scope_free() failed";
-        qvi_test_panic("%s (rc=%s)", ers, qv_strerr(rc));
+        ctu_panic("%s (rc=%s)", ers, qv_strerr(rc));
     }
 
     rc = qv_scope_free(sub_scope);
     if (rc != QV_SUCCESS) {
         ers = "qv_scope_free() failed";
-        qvi_test_panic("%s (rc=%s)", ers, qv_strerr(rc));
+        ctu_panic("%s (rc=%s)", ers, qv_strerr(rc));
     }
 
     rc = qv_scope_free(sub_sub_scope);
     if (rc != QV_SUCCESS) {
         ers = "qv_scope_free() failed";
-        qvi_test_panic("%s (rc=%s)", ers, qv_strerr(rc));
+        ctu_panic("%s (rc=%s)", ers, qv_strerr(rc));
     }
 
     MPI_Finalize();

--- a/tests/test-mpi-threads-layout.c
+++ b/tests/test-mpi-threads-layout.c
@@ -22,7 +22,7 @@
 
 #include "quo-vadis-mpi.h"
 #include "quo-vadis-pthread.h"
-#include "qvi-test-common.h"
+#include "common-test-utils.h"
 
 #include <sys/syscall.h>
 #include <omp.h>
@@ -46,26 +46,26 @@ main(void)
     rc = MPI_Init(NULL, NULL);
     if (rc != MPI_SUCCESS) {
         ers = "MPI_Init() failed";
-        qvi_test_panic("%s (rc=%d)", ers, rc);
+        ctu_panic("%s (rc=%d)", ers, rc);
     }
 
     rc = MPI_Comm_size(comm, &wsize);
     if (rc != MPI_SUCCESS) {
         ers = "MPI_Comm_size() failed";
-        qvi_test_panic("%s (rc=%d)", ers, rc);
+        ctu_panic("%s (rc=%d)", ers, rc);
     }
 
     rc = MPI_Comm_rank(comm, &wrank);
     if (rc != MPI_SUCCESS) {
         ers = "MPI_Comm_rank() failed";
-        qvi_test_panic("%s (rc=%d)", ers, rc);
+        ctu_panic("%s (rc=%d)", ers, rc);
     }
 
     qv_context_t *mpi_ctx;
     rc = qv_mpi_context_create(comm, &mpi_ctx);
     if (rc != QV_SUCCESS) {
         ers = "qv_mpi_context_create() failed";
-        qvi_test_panic("%s (rc=%s)", ers, qv_strerr(rc));
+        ctu_panic("%s (rc=%s)", ers, qv_strerr(rc));
     }
 
     qv_scope_t *mpi_scope;
@@ -76,9 +76,9 @@ main(void)
     );
     if (rc != QV_SUCCESS) {
         ers = "qv_scope_get(QV_SCOPE_PROCESS) failed";
-        qvi_test_panic("%s (rc=%s)", ers, qv_strerr(rc));
+        ctu_panic("%s (rc=%s)", ers, qv_strerr(rc));
     }
-    qvi_test_scope_report(mpi_ctx, mpi_scope, "mpi_process_scope");
+    ctu_scope_report(mpi_ctx, mpi_scope, "mpi_process_scope");
 
     rc = qv_scope_nobjs(
             mpi_ctx,
@@ -88,7 +88,7 @@ main(void)
     );
     if (rc != QV_SUCCESS) {
         ers = "qv_scope_nobjs() failed";
-        qvi_test_panic("%s (rc=%s)", ers, qv_strerr(rc));
+        ctu_panic("%s (rc=%s)", ers, qv_strerr(rc));
     }
     printf("[%d] Number of NUMA in mpi_process_scope is %d\n", wrank, n_numa);
 
@@ -102,11 +102,11 @@ main(void)
     );
     if (rc != QV_SUCCESS) {
         ers = "qv_scope_split_at() failed";
-        qvi_test_panic("%s (rc=%s)", ers, qv_strerr(rc));
+        ctu_panic("%s (rc=%s)", ers, qv_strerr(rc));
     }
-    qvi_test_scope_report(mpi_ctx, mpi_numa_scope, "mpi_numa_scope");
+    ctu_scope_report(mpi_ctx, mpi_numa_scope, "mpi_numa_scope");
 
-    qvi_test_bind_push(mpi_ctx, mpi_numa_scope);
+    ctu_bind_push(mpi_ctx, mpi_numa_scope);
 
     rc = qv_scope_taskid(
             mpi_ctx,
@@ -115,7 +115,7 @@ main(void)
     );
     if (rc != QV_SUCCESS) {
         ers = "qv_scope_taskid() failed";
-        qvi_test_panic("%s (rc=%s)", ers, qv_strerr(rc));
+        ctu_panic("%s (rc=%s)", ers, qv_strerr(rc));
     }
 
     if (my_numa_id == 0)
@@ -128,7 +128,7 @@ main(void)
         );
         if (rc != QV_SUCCESS) {
             ers = "qv_scope_nobjs() failed";
-            qvi_test_panic("%s (rc=%s)", ers, qv_strerr(rc));
+            ctu_panic("%s (rc=%s)", ers, qv_strerr(rc));
         }
 
         omp_set_num_threads(n_pu);
@@ -151,13 +151,13 @@ main(void)
             rc = qv_thread_args_set(mpi_ctx,mpi_numa_scope,thread_layout,tid,num,&args);
             if (rc != QV_SUCCESS) {
                 ers = "qv_thread_args_set() failed";
-                qvi_test_panic("%s (rc=%s)", ers, qv_strerr(rc));
+                ctu_panic("%s (rc=%s)", ers, qv_strerr(rc));
             }
 
             rc = qv_thread_layout_apply(args);
             if (rc != QV_SUCCESS) {
                 ers = "qv_thread_layout_apply failed";
-                qvi_test_panic("%s (rc=%s)", ers, qv_strerr(rc));
+                ctu_panic("%s (rc=%s)", ers, qv_strerr(rc));
             }
 
             /* Do some work here */
@@ -181,13 +181,13 @@ main(void)
             rc = qv_thread_args_set(mpi_ctx,mpi_numa_scope,thread_layout,tid,num,&args);
             if (rc != QV_SUCCESS) {
                 ers = "qv_thread_args_set() failed";
-                qvi_test_panic("%s (rc=%s)", ers, qv_strerr(rc));
+                ctu_panic("%s (rc=%s)", ers, qv_strerr(rc));
             }
 
             rc = qv_thread_layout_apply(args);
             if (rc != QV_SUCCESS) {
                 ers = "qv_thread_layout_apply failed";
-                qvi_test_panic("%s (rc=%s)", ers, qv_strerr(rc));
+                ctu_panic("%s (rc=%s)", ers, qv_strerr(rc));
             }
 
             /* Do some work here */
@@ -198,29 +198,29 @@ main(void)
         printf("[%d] Waiting for Master thread \n", wrank);
     }
 
-    qvi_test_bind_pop(mpi_ctx, mpi_numa_scope);
+    ctu_bind_pop(mpi_ctx, mpi_numa_scope);
 
     rc = qv_context_barrier(mpi_ctx);
     if (rc != QV_SUCCESS) {
         ers = "qv_context_barrier() failed";
-        qvi_test_panic("%s (rc=%s)", ers, qv_strerr(rc));
+        ctu_panic("%s (rc=%s)", ers, qv_strerr(rc));
     }
 
     rc = qv_scope_free(mpi_ctx, mpi_numa_scope);
     if (rc != QV_SUCCESS) {
         ers = "qv_scope_free() failed";
-        qvi_test_panic("%s (rc=%s)", ers, qv_strerr(rc));
+        ctu_panic("%s (rc=%s)", ers, qv_strerr(rc));
     }
 
     rc = qv_scope_free(mpi_ctx, mpi_scope);
     if (rc != QV_SUCCESS) {
         ers = "qv_scope_free() failed";
-        qvi_test_panic("%s (rc=%s)", ers, qv_strerr(rc));
+        ctu_panic("%s (rc=%s)", ers, qv_strerr(rc));
     }
 
     if (qv_mpi_context_free(mpi_ctx) != QV_SUCCESS) {
         ers = "qv_mpi_context_free() failed";
-        qvi_test_panic("%s", ers);
+        ctu_panic("%s", ers);
     }
 
     MPI_Finalize();

--- a/tests/test-mpi-threads.c
+++ b/tests/test-mpi-threads.c
@@ -23,7 +23,7 @@
 #include "quo-vadis-mpi.h"
 #include "quo-vadis-pthread.h"
 
-#include "qvi-test-common.h"
+#include "common-test-utils.h"
 
 #include <sys/syscall.h>
 #include <omp.h>
@@ -45,14 +45,14 @@ scope_report(
     int rc = qv_scope_taskid(scope, &taskid);
     if (rc != QV_SUCCESS) {
         ers = "qv_scope_taskid() failed";
-        qvi_test_panic("%s (rc=%s)", ers, qv_strerr(rc));
+        ctu_panic("%s (rc=%s)", ers, qv_strerr(rc));
     }
 
     int sgsize;
     rc = qv_scope_group_size(scope, &sgsize);
     if (rc != QV_SUCCESS) {
         ers = "qv_scope_group_size() failed";
-        qvi_test_panic("%s (rc=%s)", ers, qv_strerr(rc));
+        ctu_panic("%s (rc=%s)", ers, qv_strerr(rc));
     }
 
     printf("[%d] %s taskid is %d\n", pid, scope_name, taskid);
@@ -61,7 +61,7 @@ scope_report(
     rc = qv_scope_barrier(scope);
     if (rc != QV_SUCCESS) {
         ers = "qv_scope_barrier() failed";
-        qvi_test_panic("%s (rc=%s)", ers, qv_strerr(rc));
+        ctu_panic("%s (rc=%s)", ers, qv_strerr(rc));
     }
 }
 
@@ -83,14 +83,14 @@ change_bind(
     int rc = qv_scope_bind_push(scope);
     if (rc != QV_SUCCESS) {
         ers = "qv_bind_push() failed";
-        qvi_test_panic("%s (rc=%s)", ers, qv_strerr(rc));
+        ctu_panic("%s (rc=%s)", ers, qv_strerr(rc));
     }
 
     char *bind1s;
     rc = qv_scope_bind_string(scope, QV_BIND_STRING_AS_LIST, &bind1s);
     if (rc != QV_SUCCESS) {
         ers = "qv_bind_string() failed";
-        qvi_test_panic("%s (rc=%s)", ers, qv_strerr(rc));
+        ctu_panic("%s (rc=%s)", ers, qv_strerr(rc));
     }
     printf("[%d] New cpubind is  %s\n", pid,bind1s);
     free(bind1s);
@@ -98,14 +98,14 @@ change_bind(
     rc = qv_scope_bind_pop(scope);
     if (rc != QV_SUCCESS) {
         ers = "qv_bind_pop() failed";
-        qvi_test_panic("%s (rc=%s)", ers, qv_strerr(rc));
+        ctu_panic("%s (rc=%s)", ers, qv_strerr(rc));
     }
 
     char *bind2s;
     rc = qv_scope_bind_string(scope, QV_BIND_STRING_AS_LIST, &bind2s);
     if (rc != QV_SUCCESS) {
         ers = "qv_bind_string() failed";
-        qvi_test_panic("%s (rc=%s)", ers, qv_strerr(rc));
+        ctu_panic("%s (rc=%s)", ers, qv_strerr(rc));
     }
     printf("[%d] Popped cpubind is  %s\n", pid, bind2s);
     free(bind2s);
@@ -114,7 +114,7 @@ change_bind(
     rc = qv_scope_barrier(scope);
     if (rc != QV_SUCCESS) {
         ers = "qv_scope_barrier() failed";
-        qvi_test_panic("%s (rc=%s)", ers, qv_strerr(rc));
+        ctu_panic("%s (rc=%s)", ers, qv_strerr(rc));
     }
 }
 #endif
@@ -135,19 +135,19 @@ main(void)
    rc = MPI_Init(NULL, NULL);
    if (rc != MPI_SUCCESS) {
      ers = "MPI_Init() failed";
-     qvi_test_panic("%s (rc=%d)", ers, rc);
+     ctu_panic("%s (rc=%d)", ers, rc);
    }
 
    rc = MPI_Comm_size(comm, &wsize);
    if (rc != MPI_SUCCESS) {
      ers = "MPI_Comm_size() failed";
-     qvi_test_panic("%s (rc=%d)", ers, rc);
+     ctu_panic("%s (rc=%d)", ers, rc);
    }
 
    rc = MPI_Comm_rank(comm, &wrank);
    if (rc != MPI_SUCCESS) {
      ers = "MPI_Comm_rank() failed";
-     qvi_test_panic("%s (rc=%d)", ers, rc);
+     ctu_panic("%s (rc=%d)", ers, rc);
    }
 
    qv_scope_t *mpi_scope;
@@ -158,7 +158,7 @@ main(void)
    );
    if (rc != QV_SUCCESS) {
      ers = "qv_mpi_scope_get(QV_SCOPE_PROCESS) failed";
-     qvi_test_panic("%s (rc=%s)", ers, qv_strerr(rc));
+     ctu_panic("%s (rc=%s)", ers, qv_strerr(rc));
    }
    scope_report(wrank, mpi_scope, "mpi_process_scope");
 
@@ -169,7 +169,7 @@ main(void)
                );
    if (rc != QV_SUCCESS) {
      ers = "qv_scope_nobjs() failed";
-     qvi_test_panic("%s (rc=%s)", ers, qv_strerr(rc));
+     ctu_panic("%s (rc=%s)", ers, qv_strerr(rc));
    }
    printf("[%d] Number of NUMA in mpi_process_scope is %d\n", wrank, n_numa);
 
@@ -182,7 +182,7 @@ main(void)
     );
     if (rc != QV_SUCCESS) {
         ers = "qv_scope_split_at() failed";
-        qvi_test_panic("%s (rc=%s)", ers, qv_strerr(rc));
+        ctu_panic("%s (rc=%s)", ers, qv_strerr(rc));
     }
     scope_report(wrank, mpi_numa_scope, "mpi_numa_scope");
 
@@ -203,7 +203,7 @@ main(void)
     );
     if (rc != QV_SUCCESS) {
             ers = "qv_scope_nobjs() failed";
-            qvi_test_panic("%s (rc=%s)", ers, qv_strerr(rc));
+            ctu_panic("%s (rc=%s)", ers, qv_strerr(rc));
         }
 
     omp_set_num_threads(n_pu);
@@ -219,7 +219,7 @@ main(void)
       rc = qv_thread_context_create(&omp_ctx);
       if (rc != QV_SUCCESS) {
         ers = "qv_process_context_create() failed";
-        qvi_test_panic("%s (rc=%s)", ers, qv_strerr(rc));
+        ctu_panic("%s (rc=%s)", ers, qv_strerr(rc));
       }
 
       qv_scope_t *omp_self_scope;
@@ -230,7 +230,7 @@ main(void)
           );
       if (rc != QV_SUCCESS) {
         ers = "qv_scope_get(QV_SCOPE_PROCESS) failed";
-        qvi_test_panic("%s (rc=%s)", ers, qv_strerr(rc));
+        ctu_panic("%s (rc=%s)", ers, qv_strerr(rc));
       }
       scope_report(omp_ctx, wrank, omp_self_scope, "omp_self_scope");
 
@@ -242,7 +242,7 @@ main(void)
           );
       if (rc != QV_SUCCESS) {
         ers = "qv_scope_nobjs() failed";
-        qvi_test_panic("%s (rc=%s)", ers, qv_strerr(rc));
+        ctu_panic("%s (rc=%s)", ers, qv_strerr(rc));
       }
       printf("[%d][%d] Number of CORES in omp_self_scope is %d\n", wrank, tid, n_cores);
 
@@ -254,7 +254,7 @@ main(void)
           );
       if (rc != QV_SUCCESS) {
         ers = "qv_scope_nobjs() failed";
-        qvi_test_panic("%s (rc=%s)", ers, qv_strerr(rc));
+        ctu_panic("%s (rc=%s)", ers, qv_strerr(rc));
       }
       printf("[%d][%d] Number of PUS   in omp_self_scope is %d\n", wrank, tid, n_pus);
 
@@ -262,7 +262,7 @@ main(void)
       rc = qv_bind_string(omp_ctx, QV_BIND_STRING_AS_LIST, &binds);
       if (rc != QV_SUCCESS) {
         ers = "qv_bind_string() failed";
-        qvi_test_panic("%s (rc=%s)", ers, qv_strerr(rc));
+        ctu_panic("%s (rc=%s)", ers, qv_strerr(rc));
       }
       printf("[%d][%d] Current cpubind is %s\n", wrank, tid, binds);
       free(binds);
@@ -277,7 +277,7 @@ main(void)
                   );
       if (rc != QV_SUCCESS) {
         ers = "qv_scope_split() failed";
-        qvi_test_panic("%s (rc=%s)", ers, qv_strerr(rc));
+        ctu_panic("%s (rc=%s)", ers, qv_strerr(rc));
       }
       scope_report(omp_ctx, wrank, omp_sub_scope, "omp_sub_scope");
 
@@ -286,25 +286,25 @@ main(void)
       rc = qv_scope_free(omp_ctx, omp_sub_scope);
       if (rc != QV_SUCCESS) {
         ers = "qv_scope_free() failed";
-        qvi_test_panic("%s (rc=%s)", ers, qv_strerr(rc));
+        ctu_panic("%s (rc=%s)", ers, qv_strerr(rc));
       }
 
       rc = qv_scope_free(omp_ctx, omp_self_scope);
       if (rc != QV_SUCCESS) {
         ers = "qv_scope_free() failed";
-        qvi_test_panic("%s (rc=%s)", ers, qv_strerr(rc));
+        ctu_panic("%s (rc=%s)", ers, qv_strerr(rc));
       }
 
       rc = qv_context_barrier(omp_ctx);
       if (rc != QV_SUCCESS) {
         ers = "qv_context_barrier() failed";
-        qvi_test_panic("%s (rc=%s)", ers, qv_strerr(rc));
+        ctu_panic("%s (rc=%s)", ers, qv_strerr(rc));
       }
 
       rc = qv_thread_context_free(omp_ctx);
       if (rc != QV_SUCCESS) {
         ers = "qv_thread_context_free failed";
-        qvi_test_panic("%s (rc=%s)", ers, qv_strerr(rc));
+        ctu_panic("%s (rc=%s)", ers, qv_strerr(rc));
       }
     }
       }
@@ -316,13 +316,13 @@ main(void)
     rc = qv_scope_free(mpi_numa_scope);
     if (rc != QV_SUCCESS) {
         ers = "qv_scope_free() failed";
-        qvi_test_panic("%s (rc=%s)", ers, qv_strerr(rc));
+        ctu_panic("%s (rc=%s)", ers, qv_strerr(rc));
     }
 
     rc = qv_scope_free(mpi_scope);
     if (rc != QV_SUCCESS) {
         ers = "qv_scope_free() failed";
-        qvi_test_panic("%s (rc=%s)", ers, qv_strerr(rc));
+        ctu_panic("%s (rc=%s)", ers, qv_strerr(rc));
     }
 
    MPI_Finalize();

--- a/tests/test-omp.c
+++ b/tests/test-omp.c
@@ -4,7 +4,7 @@
  * @file test-threads.c
  */
 
-#include "qvi-test-common.h"
+#include "common-test-utils.h"
 #include "quo-vadis-omp.h"
 #include <omp.h>
 
@@ -26,11 +26,11 @@ emit_iter_info(
     );
     if (rc != QV_SUCCESS) {
         ers = "qv_bind_string() failed";
-        qvi_test_panic("%s (rc=%s)", ers, qv_strerr(rc));
+        ctu_panic("%s (rc=%s)", ers, qv_strerr(rc));
     }
     printf(
         "[%d]: thread=%d of nthread=%d of thread=%d handling iter %d on %s\n",
-        qvi_test_gettid(), omp_get_thread_num(), omp_get_team_size(2),
+        ctu_gettid(), omp_get_thread_num(), omp_get_team_size(2),
         omp_get_ancestor_thread_num(1), i, binds
     );
     free(binds);
@@ -45,13 +45,13 @@ scopei_fill(
     int rc = qv_scope_group_size(sinfo->scope, &sinfo->size);
     if (rc != QV_SUCCESS) {
         ers = "qv_scope_group_size() failed";
-        qvi_test_panic("%s (rc=%s)", ers, qv_strerr(rc));
+        ctu_panic("%s (rc=%s)", ers, qv_strerr(rc));
     }
 
     rc = qv_scope_group_rank(sinfo->scope, &sinfo->sgrank);
     if (rc != QV_SUCCESS) {
         ers = "qv_scope_group_rank() failed";
-        qvi_test_panic("%s (rc=%s)", ers, qv_strerr(rc));
+        ctu_panic("%s (rc=%s)", ers, qv_strerr(rc));
     }
 }
 
@@ -63,7 +63,7 @@ scopei_free(
     const int rc = qv_scope_free(sinfo->scope);
     if (rc != QV_SUCCESS) {
         ers = "qv_scope_free() failed";
-        qvi_test_panic("%s (rc=%s)", ers, qv_strerr(rc));
+        ctu_panic("%s (rc=%s)", ers, qv_strerr(rc));
     }
 }
 
@@ -77,7 +77,7 @@ scopei_base(
     );
     if (rc != QV_SUCCESS) {
         ers = "qv_thread_scope_get() failed";
-        qvi_test_panic("%s (rc=%s)", ers, qv_strerr(rc));
+        ctu_panic("%s (rc=%s)", ers, qv_strerr(rc));
     }
     scopei_fill(sinfo);
 }
@@ -99,7 +99,7 @@ scopei_ep(
     );
     if (rc != QV_SUCCESS) {
         ers = "qv_scope_split_at() failed";
-        qvi_test_panic("%s (rc=%s)", ers, qv_strerr(rc));
+        ctu_panic("%s (rc=%s)", ers, qv_strerr(rc));
     }
     scopei_fill(sinfo);
     // We don't need this anymore.
@@ -114,7 +114,7 @@ scopei_ep_push(
     const int rc = qv_scope_bind_push(sinfo->scope);
     if (rc != QV_SUCCESS) {
         ers = "qv_scope_bind_push() failed";
-        qvi_test_panic("%s (rc=%s)", ers, qv_strerr(rc));
+        ctu_panic("%s (rc=%s)", ers, qv_strerr(rc));
     }
 }
 
@@ -128,7 +128,7 @@ scopei_ep_pop(
     const int rc = qv_scope_bind_pop(sinfo->scope);
     if (rc != QV_SUCCESS) {
         ers = "qv_scope_bind_pop() failed";
-        qvi_test_panic("%s (rc=%s)", ers, qv_strerr(rc));
+        ctu_panic("%s (rc=%s)", ers, qv_strerr(rc));
     }
 }
 

--- a/tests/test-process-scopes.c
+++ b/tests/test-process-scopes.c
@@ -15,7 +15,7 @@
  */
 
 #include "quo-vadis-process.h"
-#include "qvi-test-common.h"
+#include "common-test-utils.h"
 
 int
 main(void)
@@ -31,15 +31,15 @@ main(void)
     );
     if (rc != QV_SUCCESS) {
         ers = "qv_scope_get(QV_SCOPE_PROCESS) failed";
-        qvi_test_panic("%s (rc=%s)", ers, qv_strerr(rc));
+        ctu_panic("%s (rc=%s)", ers, qv_strerr(rc));
     }
 
-    qvi_test_scope_report(self_scope, "self_scope");
+    ctu_scope_report(self_scope, "self_scope");
 
     rc = qv_scope_free(self_scope);
     if (rc != QV_SUCCESS) {
         ers = "qv_scope_free() failed";
-        qvi_test_panic("%s (rc=%s)", ers, qv_strerr(rc));
+        ctu_panic("%s (rc=%s)", ers, qv_strerr(rc));
     }
 
     qv_scope_t *base_scope;
@@ -48,31 +48,31 @@ main(void)
     );
     if (rc != QV_SUCCESS) {
         ers = "qv_scope_get(QV_SCOPE_USER) failed";
-        qvi_test_panic("%s (rc=%s)", ers, qv_strerr(rc));
+        ctu_panic("%s (rc=%s)", ers, qv_strerr(rc));
     }
 
-    qvi_test_scope_report(base_scope, "base_scope");
+    ctu_scope_report(base_scope, "base_scope");
 
     int srank;
     rc = qv_scope_group_rank(base_scope, &srank);
     if (rc != QV_SUCCESS) {
         ers = "qv_scope_group_rank() failed";
-        qvi_test_panic("%s (rc=%s)", ers, qv_strerr(rc));
+        ctu_panic("%s (rc=%s)", ers, qv_strerr(rc));
     }
     if (srank != 0) {
         ers = "Invalid task ID detected";
-        qvi_test_panic("%s (rc=%s)", ers, qv_strerr(rc));
+        ctu_panic("%s (rc=%s)", ers, qv_strerr(rc));
     }
 
     int sgsize;
     rc = qv_scope_group_size(base_scope, &sgsize);
     if (rc != QV_SUCCESS) {
         ers = "qv_scope_group_size() failed";
-        qvi_test_panic("%s (rc=%s)", ers, qv_strerr(rc));
+        ctu_panic("%s (rc=%s)", ers, qv_strerr(rc));
     }
     if (sgsize != 1) {
         ers = "Invalid number of tasks detected";
-        qvi_test_panic("%s (rc=%s)", ers, qv_strerr(rc));
+        ctu_panic("%s (rc=%s)", ers, qv_strerr(rc));
     }
 
     int n_numa;
@@ -81,7 +81,7 @@ main(void)
     );
     if (rc != QV_SUCCESS) {
         ers = "qv_scope_nobjs() failed";
-        qvi_test_panic("%s (rc=%s)", ers, qv_strerr(rc));
+        ctu_panic("%s (rc=%s)", ers, qv_strerr(rc));
     }
     printf("[%d] Number of NUMA in base_scope is %d\n", pid, n_numa);
 
@@ -92,7 +92,7 @@ main(void)
     );
     if (rc != QV_SUCCESS) {
         ers = "qv_scope_split() failed";
-        qvi_test_panic("%s (rc=%s)", ers, qv_strerr(rc));
+        ctu_panic("%s (rc=%s)", ers, qv_strerr(rc));
     }
 
     rc = qv_scope_nobjs(
@@ -100,24 +100,24 @@ main(void)
     );
     if (rc != QV_SUCCESS) {
         ers = "qv_scope_nobjs() failed";
-        qvi_test_panic("%s (rc=%s)", ers, qv_strerr(rc));
+        ctu_panic("%s (rc=%s)", ers, qv_strerr(rc));
     }
     printf("[%d] Number of NUMA in sub_scope is %d\n", pid, n_numa);
 
-    qvi_test_scope_report(sub_scope, "sub_scope");
+    ctu_scope_report(sub_scope, "sub_scope");
 
-    qvi_test_change_bind(sub_scope);
+    ctu_change_bind(sub_scope);
 
     rc = qv_scope_free(base_scope);
     if (rc != QV_SUCCESS) {
         ers = "qv_scope_free() failed";
-        qvi_test_panic("%s (rc=%s)", ers, qv_strerr(rc));
+        ctu_panic("%s (rc=%s)", ers, qv_strerr(rc));
     }
 
     rc = qv_scope_free(sub_scope);
     if (rc != QV_SUCCESS) {
         ers = "qv_scope_free() failed";
-        qvi_test_panic("%s (rc=%s)", ers, qv_strerr(rc));
+        ctu_panic("%s (rc=%s)", ers, qv_strerr(rc));
     }
 
     return EXIT_SUCCESS;

--- a/tests/test-progress-thread.c
+++ b/tests/test-progress-thread.c
@@ -3,7 +3,7 @@
 #include <pthread.h>
 #include "quo-vadis-mpi.h"
 #include "quo-vadis-pthread.h"
-#include "qvi-test-common.h"
+#include "common-test-utils.h"
 
 /*
  * QV Todo:
@@ -41,7 +41,7 @@ void *thread_work(void *arg)
 
     if (rc != QV_SUCCESS) {
         ers = "qv_bind_get_list_as_string() failed";
-        qvi_test_panic("%s (rc=%s)", ers, qv_strerr(rc));
+        ctu_panic("%s (rc=%s)", ers, qv_strerr(rc));
     }
 
     printf("Progress thread running on %s\n", binds);
@@ -59,28 +59,28 @@ int main(int argc, char *argv[])
     int rc = MPI_Init(&argc, &argv);
     if (rc != MPI_SUCCESS) {
         ers = "MPI_Init() failed";
-        qvi_test_panic("%s (rc=%d)", ers, rc);
+        ctu_panic("%s (rc=%d)", ers, rc);
     }
 
     int wsize;
     rc = MPI_Comm_size(comm, &wsize);
     if (rc != MPI_SUCCESS) {
         ers = "MPI_Comm_size() failed";
-        qvi_test_panic("%s (rc=%d)", ers, rc);
+        ctu_panic("%s (rc=%d)", ers, rc);
     }
 
     int wrank;
     rc = MPI_Comm_rank(comm, &wrank);
     if (rc != MPI_SUCCESS) {
         ers = "MPI_Comm_rank() failed";
-        qvi_test_panic("%s (rc=%d)", ers, rc);
+        ctu_panic("%s (rc=%d)", ers, rc);
     }
 
     qv_scope_t *user_scope;
     rc = qv_mpi_scope_get(comm, QV_SCOPE_USER, &user_scope);
     if (rc != QV_SUCCESS) {
         ers = "qv_mpi_scope_get() failed";
-        qvi_test_panic("%s (rc=%s)", ers, qv_strerr(rc));
+        ctu_panic("%s (rc=%s)", ers, qv_strerr(rc));
     }
 
     /* Split user scope evenly across tasks */
@@ -88,14 +88,14 @@ int main(int argc, char *argv[])
     rc = qv_scope_split(user_scope, wsize, wrank, &task_scope);
     if (rc != QV_SUCCESS) {
         ers = "qv_scope_split() failed";
-        qvi_test_panic("%s (rc=%s)", ers, qv_strerr(rc));
+        ctu_panic("%s (rc=%s)", ers, qv_strerr(rc));
     }
 
     /* Push into my task scope */
     rc = qv_scope_bind_push(task_scope);
     if (rc != QV_SUCCESS) {
         ers = "qv_bind_push() failed";
-        qvi_test_panic("%s (rc=%s)", ers, qv_strerr(rc));
+        ctu_panic("%s (rc=%s)", ers, qv_strerr(rc));
     }
 
     /* Where did I end up? */
@@ -103,7 +103,7 @@ int main(int argc, char *argv[])
     rc = qv_scope_bind_string(task_scope, QV_BIND_STRING_AS_LIST, &binds);
     if (rc != QV_SUCCESS) {
         ers = "qv_bind_get_list_as_string() failed";
-        qvi_test_panic("%s (rc=%s)", ers, qv_strerr(rc));
+        ctu_panic("%s (rc=%s)", ers, qv_strerr(rc));
     }
     printf("[%d] Split: running on %s\n", wrank, binds);
     free(binds);
@@ -134,7 +134,7 @@ int main(int argc, char *argv[])
     rc = qv_scope_nobjs(task_scope, QV_HW_OBJ_CORE, &ncores);
     if (rc != QV_SUCCESS) {
         ers = "qv_scope_nobjs() failed";
-        qvi_test_panic("%s (rc=%s)", ers, qv_strerr(rc));
+        ctu_panic("%s (rc=%s)", ers, qv_strerr(rc));
     }
 
     qv_scope_t *wk_scope;
@@ -142,65 +142,65 @@ int main(int argc, char *argv[])
             &wk_scope);
     if (rc != QV_SUCCESS) {
         ers = "qv_scope_create() failed";
-        qvi_test_panic("%s (rc=%s)", ers, qv_strerr(rc));
+        ctu_panic("%s (rc=%s)", ers, qv_strerr(rc));
     }
 
     qv_scope_t *ut_scope;
     rc = qv_scope_create(task_scope, QV_HW_OBJ_CORE, 1, 0, &ut_scope);
     if (rc != QV_SUCCESS) {
         ers = "qv_scope_create() failed";
-        qvi_test_panic("%s (rc=%s)", ers, qv_strerr(rc));
+        ctu_panic("%s (rc=%s)", ers, qv_strerr(rc));
     }
 
     /* Test work scope */
     rc = qv_scope_bind_push(wk_scope);
     if (rc != QV_SUCCESS) {
         ers = "qv_bind_push() failed";
-        qvi_test_panic("%s (rc=%s)", ers, qv_strerr(rc));
+        ctu_panic("%s (rc=%s)", ers, qv_strerr(rc));
     }
     rc = qv_scope_bind_string(wk_scope, QV_BIND_STRING_AS_LIST, &binds);
     if (rc != QV_SUCCESS) {
         ers = "qv_bind_get_list_as_string() failed";
-        qvi_test_panic("%s (rc=%s)", ers, qv_strerr(rc));
+        ctu_panic("%s (rc=%s)", ers, qv_strerr(rc));
     }
     printf("[%d] Work scope: running on %s\n", wrank, binds);
     free(binds);
     rc = qv_scope_bind_pop(wk_scope);
     if (rc != QV_SUCCESS) {
         ers = "qv_bind_pop() failed";
-        qvi_test_panic("%s (rc=%s)", ers, qv_strerr(rc));
+        ctu_panic("%s (rc=%s)", ers, qv_strerr(rc));
     }
 
     /* Test utility scope */
     rc = qv_scope_bind_push(ut_scope);
     if (rc != QV_SUCCESS) {
         ers = "qv_bind_push() failed";
-        qvi_test_panic("%s (rc=%s)", ers, qv_strerr(rc));
+        ctu_panic("%s (rc=%s)", ers, qv_strerr(rc));
     }
     rc = qv_scope_bind_string(ut_scope, QV_BIND_STRING_AS_LIST, &binds);
     if (rc != QV_SUCCESS) {
         ers = "qv_bind_get_list_as_string() failed";
-        qvi_test_panic("%s (rc=%s)", ers, qv_strerr(rc));
+        ctu_panic("%s (rc=%s)", ers, qv_strerr(rc));
     }
     printf("[%d] Utility scope: running on %s\n", wrank, binds);
     free(binds);
     rc = qv_scope_bind_pop(ut_scope);
     if (rc != QV_SUCCESS) {
         ers = "qv_bind_pop() failed";
-        qvi_test_panic("%s (rc=%s)", ers, qv_strerr(rc));
+        ctu_panic("%s (rc=%s)", ers, qv_strerr(rc));
     }
 
     /* Clean up for now */
     rc = qv_scope_free(ut_scope);
     if (rc != QV_SUCCESS) {
         ers = "qv_scope_free() failed";
-        qvi_test_panic("%s (rc=%s)", ers, qv_strerr(rc));
+        ctu_panic("%s (rc=%s)", ers, qv_strerr(rc));
     }
 
     rc = qv_scope_free(wk_scope);
     if (rc != QV_SUCCESS) {
         ers = "qv_scope_free() failed";
-        qvi_test_panic("%s (rc=%s)", ers, qv_strerr(rc));
+        ctu_panic("%s (rc=%s)", ers, qv_strerr(rc));
     }
 
 
@@ -218,7 +218,7 @@ int main(int argc, char *argv[])
     rc = qv_mpi_context_create(comm, &ctx2);
     if (rc != QV_SUCCESS) {
         ers = "qv_mpi_context_create() failed";
-        qvi_test_panic("%s (rc=%s)", ers, qv_strerr(rc));
+        ctu_panic("%s (rc=%s)", ers, qv_strerr(rc));
     }
 
     /* Get scope from which to derive the progress thread.
@@ -231,7 +231,7 @@ int main(int argc, char *argv[])
     rc = qv_scope_get(ctx2, MY_INTRINSIC_SCOPE, &base_scope);
     if (rc != QV_SUCCESS) {
         ers = "qv_scope_get() failed";
-        qvi_test_panic("%s (rc=%s)", ers, qv_strerr(rc));
+        ctu_panic("%s (rc=%s)", ers, qv_strerr(rc));
     }
 
     /* Test we have PUs to use in the base scope */
@@ -239,7 +239,7 @@ int main(int argc, char *argv[])
     rc = qv_scope_nobjs(ctx2, base_scope, QV_HW_OBJ_PU, &npus);
     if (rc != QV_SUCCESS) {
         ers = "qv_scope_nobjs() failed";
-        qvi_test_panic("%s (rc=%s)", ers, qv_strerr(rc));
+        ctu_panic("%s (rc=%s)", ers, qv_strerr(rc));
     }
     printf("[%d] Base scope: npus=%d\n", wrank, npus);
 
@@ -249,7 +249,7 @@ int main(int argc, char *argv[])
         rc = qv_scope_create(ctx2, base_scope, QV_HW_OBJ_PU, 1, 0, &pt_scope);
         if (rc != QV_SUCCESS) {
             ers = "qv_scope_create() failed";
-            qvi_test_panic("%s (rc=%s)", ers, qv_strerr(rc));
+            ctu_panic("%s (rc=%s)", ers, qv_strerr(rc));
         }
     }
 
@@ -273,13 +273,13 @@ int main(int argc, char *argv[])
     rc = qv_scope_free(ctx2, pt_scope);
     if (rc != QV_SUCCESS) {
         ers = "qv_scope_free() failed";
-        qvi_test_panic("%s (rc=%s)", ers, qv_strerr(rc));
+        ctu_panic("%s (rc=%s)", ers, qv_strerr(rc));
     }
 
     rc = qv_scope_free(ctx2, base_scope);
     if (rc != QV_SUCCESS) {
         ers = "qv_scope_free() failed";
-        qvi_test_panic("%s (rc=%s)", ers, qv_strerr(rc));
+        ctu_panic("%s (rc=%s)", ers, qv_strerr(rc));
     }
 
 
@@ -290,13 +290,13 @@ int main(int argc, char *argv[])
     rc = qv_scope_free(ctx, task_scope);
     if (rc != QV_SUCCESS) {
         ers = "qv_scope_free() failed";
-        qvi_test_panic("%s (rc=%s)", ers, qv_strerr(rc));
+        ctu_panic("%s (rc=%s)", ers, qv_strerr(rc));
     }
 
     rc = qv_scope_free(ctx, user_scope);
     if (rc != QV_SUCCESS) {
         ers = "qv_scope_free() failed";
-        qvi_test_panic("%s (rc=%s)", ers, qv_strerr(rc));
+        ctu_panic("%s (rc=%s)", ers, qv_strerr(rc));
     }
 #endif
     MPI_Finalize();


### PR DESCRIPTION
Update common test infrastructure by avoiding the use of a qvi_ prefix. Instead use ctu_ to avoid potential confusion with internal QV APIs.

Fixes #284.