### PR TITLE
Add first cut of Pthread group split support.

### DIFF
--- a/src/qvi-group-omp.h
+++ b/src/qvi-group-omp.h
@@ -72,7 +72,7 @@ public:
     );
 
     virtual int
-    thsplit(
+    thread_split(
         int,
         qvi_group **
     ) {

--- a/src/qvi-group.cc
+++ b/src/qvi-group.cc
@@ -1,6 +1,6 @@
 /* -*- Mode: C++; c-basic-offset:4; indent-tabs-mode:nil -*- */
 /*
- * Copyright (c) 2021-2024 Triad National Security, LLC
+ * Copyright (c) 2021-2025 Triad National Security, LLC
  *                         All rights reserved.
  *
  * This file is part of the quo-vadis project. See the LICENSE file at the
@@ -23,12 +23,16 @@ qvi_group::hwloc(void)
 }
 
 int
-qvi_group::thsplit(
+qvi_group::thread_split(
     int nthreads,
     qvi_group **child
 ) {
     qvi_group_pthread *ichild = nullptr;
-    const int rc = qvi_new(&ichild, nthreads);
+    // This is the entry point for creating a new thread group, so nullptr
+    // passed to signal that a new context must be created by the new
+    // qvi_group_pthread. Also note this is called by a single thread of
+    // execution (i.e., the parent process).
+    const int rc = qvi_new(&ichild, nullptr, nthreads);
     if (qvi_unlikely(rc != QV_SUCCESS)) {
         qvi_delete(&ichild);
     }
@@ -44,11 +48,26 @@ qvi_group::next_id(
     // infrastructure (e.g., QVI_MPI_GROUP_WORLD) will never equal or exceed
     // this value.
     static std::atomic<qvi_group_id_t> group_id(64);
-    if (group_id == UINT64_MAX) {
-        qvi_log_error("Group ID space exhausted");
+    if (qvi_unlikely(group_id == UINT64_MAX)) {
+        qvi_log_error("Group ID space exhausted.");
         return QV_ERR_OOR;
     }
     *gid = group_id++;
+    return QV_SUCCESS;
+}
+
+int
+qvi_group::next_ids(
+    size_t n,
+    std::vector<qvi_group_id_t> &gids
+) {
+    gids.resize(n);
+    for (size_t i = 0; i < n; ++i) {
+        qvi_group_id_t gid = 0;
+        const int rc = next_id(&gid);
+        if (qvi_unlikely(rc != QV_SUCCESS)) return rc;
+        gids[i] = gid;
+    }
     return QV_SUCCESS;
 }
 

--- a/src/qvi-group.h
+++ b/src/qvi-group.h
@@ -61,10 +61,11 @@ struct qvi_group : qvi_refc {
         qvi_group **child
     ) = 0;
     /**
-     * Creates a new thread group by splitting off of the caller's group.
+     * Creates a new thread group by splitting off of the calling process'
+     * group.
      */
     virtual int
-    thsplit(
+    thread_split(
         int nthreads,
         qvi_group **child
     );
@@ -97,6 +98,12 @@ struct qvi_group : qvi_refc {
     static int
     next_id(
         qvi_group_id_t *gid
+    );
+    /** Populates gids with n unique group IDs after each call. */
+    static int
+    next_ids(
+        size_t n,
+        std::vector<qvi_group_id_t> &gids
     );
 };
 

--- a/src/qvi-pthread.h
+++ b/src/qvi-pthread.h
@@ -15,14 +15,24 @@
 #define QVI_PTHREAD_H
 
 #include "qvi-common.h"
+#include "qvi-group.h"
 #include "qvi-subgroup.h"
 #include "qvi-bbuff.h"
 
 typedef void *(*qvi_pthread_routine_fun_ptr_t)(void *);
-// Foward declaration.
+// Forward declaration.
 struct qvi_pthread_group;
 
-struct qvi_pthread_group_pthread_create_args_s {
+/**
+ * This structure holds Pthread group context information that is relevant to
+ * all threads that are spawned by a common parent process.
+ */
+struct qvi_pthread_group_context : public qvi_refc {
+    /** */
+    std::unordered_map<qvi_group_id_t, qvi_pthread_group *> groupid2thgroup;
+};
+
+struct qvi_pthread_group_pthread_create_args {
     /** Thread group. */
     qvi_pthread_group *group = nullptr;
     /** The routine to call after group construction. */
@@ -30,9 +40,9 @@ struct qvi_pthread_group_pthread_create_args_s {
     /** Thread routine arguments. */
     void *throutine_argp = nullptr;
     /** Default constructor. */
-    qvi_pthread_group_pthread_create_args_s(void) = delete;
+    qvi_pthread_group_pthread_create_args(void) = delete;
     /** Constructor. */
-    qvi_pthread_group_pthread_create_args_s(
+    qvi_pthread_group_pthread_create_args(
         qvi_pthread_group *group_a,
         qvi_pthread_routine_fun_ptr_t throutine_a,
         void *throutine_argp_a
@@ -43,6 +53,8 @@ struct qvi_pthread_group_pthread_create_args_s {
 
 struct qvi_pthread_group {
 private:
+    /** Context information. */
+    qvi_pthread_group_context *m_context = nullptr;
     /** Group size. */
     int m_size = 0;
     /** Holds the thread TIDs in this group. */
@@ -53,36 +65,56 @@ private:
     std::map<pid_t, qvi_task *> m_tid2task;
     /** Used for mutexy things. */
     std::mutex m_mutex;
-    /** Used for monitory things */
+    /** Used for monitory things. */
     std::condition_variable m_condition;
     /** Used for barrier things. */
     pthread_barrier_t m_barrier;
-    /** Used for gather exchanges*/
-    //C++ flavor
-    //std::vector<qvi_bbuff *> m_data_g;
+    /** Used for gather exchanges. */
     qvi_bbuff **m_data_g = nullptr;
-    /** Used for scatter exchanges*/
+    /** Used for scatter exchanges. */
     qvi_bbuff ***m_data_s = nullptr;
-    /** Used for split */
+    /** Shared color, key, rank scratch pad used for splitting. */
     qvi_subgroup_color_key_rank *m_ckrs = nullptr;
+    /** Shared sub-group IDs. */
+    std::vector<qvi_group_id_t> m_subgroup_gids;
+    /** */
+    int
+    m_init_by_a_single_thread(
+        qvi_pthread_group_context *ctx,
+        int group_size
+    );
+    /** */
+    static int
+    m_finish_init_by_all_threads(
+        qvi_pthread_group *group
+    );
+    /** */
     int
     m_subgroup_info(
         int color,
         int key,
-        qvi_subgroup_info *sginfo
+        qvi_subgroup_info &sginfo
     );
 public:
     /** Default constructor. */
     qvi_pthread_group(void) = delete;
     /**
-     * Constructor. This is called by the parent process to construct the
-     * maximum amount of infrastructure possible. The rest of group construction
-     * has to be performed after pthread_create() time. See
-     * call_first_from_pthread_create() for more details.
+     * Constructor. Called by sginfo.rank == 0.
      */
     qvi_pthread_group(
-        int group_size,
-        int rank_in_group
+        qvi_pthread_group *parent_group,
+        const qvi_subgroup_info &sginfo
+    );
+    /**
+     * Constructor. This is called by the parent process to construct the
+     * maximum amount of infrastructure possible. The rest of group construction
+     * has to be performed after pthread_create() or during
+     * qvi_pthread_group::split() time. See call_first_from_pthread_create() for
+     * more details.
+     */
+    qvi_pthread_group(
+        qvi_pthread_group_context *ctx,
+        int group_size
     );
     /**
      * This function shall be called by pthread_create() to finish group

--- a/src/qvi-subgroup.h
+++ b/src/qvi-subgroup.h
@@ -1,6 +1,6 @@
 /* -*- Mode: C++; c-basic-offset:4; indent-tabs-mode:nil -*- */
 /*
- * Copyright (c) 2022-2024 Triad National Security, LLC
+ * Copyright (c) 2022-2025 Triad National Security, LLC
  *                         All rights reserved.
  *
  * Copyright (c) 2022-2024 Inria
@@ -29,9 +29,11 @@
 struct qvi_subgroup_info {
     /** Number of sub-groups created from split. */
     int ngroups = 0;
-    /** Number of members in this sub-group. */
+    /** My sub-group index (from 0 to ngroups - 1). */
+    int index = 0;
+    /** Number of members in my sub-group. */
     int size = 0;
-    /** My rank in this sub-group. */
+    /** My rank in my sub-group. */
     int rank = 0;
 };
 
@@ -43,7 +45,7 @@ struct qvi_subgroup_color_key_rank {
     int color = -1;
     int key = -1;
     int rank = -1;
-    int ncolors = 0;
+    int ncolors = -1;
 
     static bool
     by_color(

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -151,7 +151,6 @@ if(MPI_FOUND)
     target_link_libraries(
         test-pthread-split
         quo-vadis
-        quo-vadis-mpi
     )
 
     add_executable(

--- a/tests/test-pthread-split.c
+++ b/tests/test-pthread-split.c
@@ -1,6 +1,6 @@
 /* -*- Mode: C; c-basic-offset:4; indent-tabs-mode:nil -*- */
 
-#include "quo-vadis-mpi.h"
+#include "quo-vadis-process.h"
 #include "quo-vadis-pthread.h"
 #include "common-test-utils.h"
 
@@ -29,11 +29,14 @@ thread_work(
         ers = "qv_scope_group_rank failed";
         ctu_panic("%s (rc=%s)", ers, qv_strerr(rc));
     }
-
+#if 0
     ctu_scope_report(scope, "thread_scope_in_thread_routine");
     ctu_emit_task_bind(scope);
+#endif
 
-    printf("[%d] ============ Thread %d splitting in two pieces\n", tid, rank);
+    if (rank == 0) {
+        printf("[%d] ============ Splitting thread scopes in two\n", tid);
+    }
     qv_scope_t *pthread_subscope = NULL;
     rc = qv_scope_split(scope, 2, rank, &pthread_subscope);
     if (rc != QV_SUCCESS) {
@@ -44,12 +47,13 @@ thread_work(
     ctu_scope_report(pthread_subscope, "thread_subscope");
     ctu_emit_task_bind(pthread_subscope);
 
-
+#if 0
     rc = qv_scope_free(pthread_subscope);
     if (rc != QV_SUCCESS) {
         ers = "qv_scope_free failed";
         ctu_panic("%s (rc=%s)", ers, qv_strerr(rc));
     }
+#endif
 
     return NULL;
 }
@@ -59,57 +63,31 @@ main(void)
 {
     char const *ers = NULL;
     const pid_t tid = ctu_gettid();
-    int wrank, wsize;
 
-    int rc = MPI_Init(NULL, NULL);
-    if (rc != MPI_SUCCESS) {
-        ers = "MPI_Init() failed";
-        ctu_panic("%s (rc=%d)", ers, rc);
-    }
+    fprintf(stdout,"# Starting Pthreads test.\n");
 
-    MPI_Comm comm = MPI_COMM_WORLD;
-    rc = MPI_Comm_size(comm, &wsize);
-    if (rc != MPI_SUCCESS) {
-        ers = "MPI_Comm_size() failed";
-        ctu_panic("%s (rc=%d)", ers, rc);
-    }
-    // TODO: As Edgar pointed out, this will work only in the single process
-    // case. The mpi_scope needs to be split to get a new single MPI scope.
-    if (wsize != 1) {
-        ctu_panic("!!! This test works only with one MPI process!");
-    }
-
-    rc = MPI_Comm_rank(comm, &wrank);
-    if (rc != MPI_SUCCESS) {
-        ers = "MPI_Comm_rank() failed";
-        ctu_panic("%s (rc=%d)", ers, rc);
-    }
-
-    if (wrank == 0) {
-        fprintf(stdout,"# Starting Hybrid MPI + Pthreads test.\n");
-    }
-
-    qv_scope_t *mpi_scope;
-    rc = qv_mpi_scope_get(comm, QV_SCOPE_JOB, &mpi_scope);
+    qv_scope_t *base_scope;
+    int rc = qv_process_scope_get(
+        QV_SCOPE_PROCESS, &base_scope
+    );
     if (rc != QV_SUCCESS) {
-        ers = "qv_scope_get() failed";
+        ers = "qv_process_scope_get() failed";
         ctu_panic("%s (rc=%s)", ers, qv_strerr(rc));
     }
 
     int ncores = 0;
-    rc = qv_scope_nobjs(mpi_scope, QV_HW_OBJ_CORE, &ncores);
+    rc = qv_scope_nobjs(base_scope, QV_HW_OBJ_CORE, &ncores);
     if (rc != QV_SUCCESS) {
         ers = "qv_scope_nobjs() failed";
         ctu_panic("%s (rc=%s)", ers, qv_strerr(rc));
     }
 
-    ctu_scope_report(mpi_scope, "mpi_scope");
-    ctu_emit_task_bind(mpi_scope);
+    ctu_emit_task_bind(base_scope);
     //
     // Test qv_pthread_scope_split
     //
-    int npieces = 2;
-    int nthreads = ncores;
+    const int npieces = 2;
+    const int nthreads = ncores;
     int stride = 1;
     int colors[nthreads];
 
@@ -121,28 +99,28 @@ main(void)
     for (int i = 0 ; i < nthreads ; i++) {
         colors[i] = i % npieces;
     }
-
+#if 0
     printf("Manual values: ");
     for (int i = 0 ; i < nthreads ; i++) {
         printf("val[%i]:%i | ",i,colors[i]);
     }
     printf("\n");
-
+#endif
     rc = qv_pthread_colors_fill(colors, nthreads, QV_POLICY_PACKED, stride, npieces);
     if (rc != QV_SUCCESS) {
         ers = "qv_pthread_colors_fill() failed";
         ctu_panic("%s (rc=%s)", ers, qv_strerr(rc));
     }
-
+#if 0
     fprintf(stdout,"Filled values: ");
     for (int i = 0 ; i < nthreads ; i++) {
         fprintf(stdout,"val[%i]:%i | ",i,colors[i]);
     }
     fprintf(stdout,"\n");
-
+#endif
     qv_scope_t **th_scopes = NULL;
     rc = qv_pthread_scope_split(
-        mpi_scope, npieces, colors, nthreads, &th_scopes
+        base_scope, npieces, colors, nthreads, &th_scopes
     );
     if (rc != QV_SUCCESS) {
         ers = "qv_pthread_scope_split() failed";
@@ -253,13 +231,11 @@ main(void)
         ctu_panic("%s (rc=%s)", ers, qv_strerr(rc));
     }
 #endif
-    rc = qv_scope_free(mpi_scope);
+    rc = qv_scope_free(base_scope);
     if (rc != QV_SUCCESS) {
         ers = "qv_scope_free() failed";
         ctu_panic("%s (rc=%s)", ers, qv_strerr(rc));
     }
-
-    MPI_Finalize();
 
     return EXIT_SUCCESS;
 }


### PR DESCRIPTION
Please note that this is a work in progress, so a lot of cleanup and fixes are needed.

This adds group splitting capability to Pthreads. That said, there are still races and memory leaks that I'm working out. In particular, there appears to be a problem in qvi_hwsplit_coll::split() that results in inconsistent colorp values (and perhaps other things).