### PR TITLE
Fix potential races in Pthread gather/scatter.

### DIFF
--- a/src/qvi-scope.cc
+++ b/src/qvi-scope.cc
@@ -237,10 +237,6 @@ qv_scope::split(
     );
     rc = chwsplit.split(&colorp, &hwpool);
     if (rc != QV_SUCCESS) goto out;
-    // TODO(skg) In the threaded case it looks like there is a race here or
-    // something else is wrong. See colorp.
-    //qvi_log_debug("SCOPE SPLIT npieces={}, color={} colorp={}", npieces, color, colorp);
-
     // Split underlying group. Notice the use of colorp here.
     rc = m_group->split(
         colorp, m_group->rank(), &group


### PR DESCRIPTION
This likely isn't an ideal fix, but it appears to address the issues in qvi_hwsplit_coll::split() that I was seeing earlier.