### PR TITLE
Allow users to specify bind string listing types.

### DIFF
--- a/include/quo-vadis.h
+++ b/include/quo-vadis.h
@@ -1,6 +1,6 @@
 /* -*- Mode: C; c-basic-offset:4; indent-tabs-mode:nil -*- */
 /*
- * Copyright (c) 2020-2024 Triad National Security, LLC
+ * Copyright (c) 2020-2025 Triad National Security, LLC
  *                         All rights reserved.
  *
  * Copyright (c) 2020-2021 Lawrence Livermore National Security, LLC
@@ -100,12 +100,19 @@ typedef enum {
 } qv_hw_obj_type_t;
 
 /**
- * Binding string representation formats.
+ * Binding string representation format flags.
  */
-typedef enum {
-    QV_BIND_STRING_AS_BITMAP = 0,
-    QV_BIND_STRING_AS_LIST
-} qv_bind_string_format_t;
+typedef int qv_bind_string_flags_t;
+
+/**
+ * Output the logical binding.
+ */
+const qv_bind_string_flags_t QV_BIND_STRING_LOGICAL = 0x00000001;
+
+/**
+ * Output the physical (OS) binding.
+ */
+const qv_bind_string_flags_t QV_BIND_STRING_PHYSICAL = 0x00000002;
 
 /**
  * Automatic grouping options for qv_scope_split(). The following values can be
@@ -277,7 +284,7 @@ qv_scope_bind_pop(
 int
 qv_scope_bind_string(
     qv_scope_t *scope,
-    qv_bind_string_format_t format,
+    qv_bind_string_flags_t flags,
     char **str
 );
 

--- a/src/fortran/quo-vadisf.f90
+++ b/src/fortran/quo-vadisf.f90
@@ -1,5 +1,5 @@
 !
-! Copyright (c) 2013-2024 Triad National Security, LLC
+! Copyright (c) 2013-2025 Triad National Security, LLC
 !                         All rights reserved.
 !
 ! This file is part of the quo-vadis project. See the LICENSE file at the
@@ -96,13 +96,13 @@ module quo_vadisf
     parameter (QV_HW_OBJ_LAST = 11)
 
     !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-    ! Binding string representaiton formats.
+    ! Binding string representation format flags.
     !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-    integer(c_int) QV_BIND_STRING_AS_BITMAP
-    integer(c_int) QV_BIND_STRING_AS_LIST
+    integer(c_int), parameter :: QV_BIND_STRING_LOGICAL = &
+        int(Z'00000001', kind=c_int)
 
-    parameter (QV_BIND_STRING_AS_BITMAP = 0)
-    parameter (QV_BIND_STRING_AS_LIST = 1)
+    integer(c_int), parameter :: QV_BIND_STRING_PHYSICAL = &
+        int(Z'00000002', kind=c_int)
 
     !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
     ! Automatic grouping options for qv_scope_split().

--- a/src/quo-vadis.cc
+++ b/src/quo-vadis.cc
@@ -62,14 +62,14 @@ qv_scope_bind_pop(
 int
 qv_scope_bind_string(
     qv_scope_t *scope,
-    qv_bind_string_format_t format,
+    qv_bind_string_flags_t flags,
     char **str
 ) {
     if (qvi_unlikely(!scope || !str)) {
         return QV_ERR_INVLD_ARG;
     }
     try {
-        return scope->bind_string(format, str);
+        return scope->bind_string(flags, str);
     }
     qvi_catch_and_return();
 }

--- a/src/qvi-bbuff-rmi.h
+++ b/src/qvi-bbuff-rmi.h
@@ -459,7 +459,7 @@ qvi_bbuff_rmi_pack_item_impl(
     }
     // Non-null data.
     char *datas = nullptr;
-    int rc = qvi_hwloc_bitmap_asprintf(NULL, data, &datas);
+    int rc = qvi_hwloc_bitmap_asprintf(data, &datas);
     if (qvi_unlikely(rc != QV_SUCCESS)) return rc;
     // We are sending the string representation of the cpuset.
     rc = buff->append(datas, strlen(datas) + 1);

--- a/src/qvi-hwloc.h
+++ b/src/qvi-hwloc.h
@@ -1,6 +1,6 @@
 /* -*- Mode: C++; c-basic-offset:4; indent-tabs-mode:nil -*- */
 /*
- * Copyright (c) 2020-2024 Triad National Security, LLC
+ * Copyright (c) 2020-2025 Triad National Security, LLC
  *                         All rights reserved.
  *
  * Copyright (c) 2020-2021 Lawrence Livermore National Security, LLC
@@ -174,20 +174,10 @@ qvi_hwloc_get_nobjs_by_type(
 );
 
 /**
- *
- */
-int
-qvi_hwloc_emit_cpubind(
-   qvi_hwloc_t *hwl,
-   pid_t task_id
-);
-
-/**
  * Caller is responsible for freeing returned resources.
  */
 int
 qvi_hwloc_bitmap_asprintf(
-    hwloc_topology_t topo,
     hwloc_const_cpuset_t cpuset,
     char **result
 );
@@ -197,7 +187,6 @@ qvi_hwloc_bitmap_asprintf(
  */
 int
 qvi_hwloc_bitmap_list_asprintf(
-    hwloc_topology_t topo,
     hwloc_const_cpuset_t cpuset,
     char **result
 );
@@ -538,10 +527,10 @@ qvi_hwloc_get_devices_in_bitmap(
 );
 
 int
-qvi_hwloc_bitmap_string(
-    hwloc_topology_t topo,
+qvi_hwloc_bind_string(
+    qvi_hwloc_t *hwloc,
     hwloc_const_bitmap_t bitmap,
-    qv_bind_string_format_t format,
+    qv_bind_string_flags_t flags,
     char **result
 );
 

--- a/src/qvi-scope.cc
+++ b/src/qvi-scope.cc
@@ -206,16 +206,18 @@ qv_scope::bind_pop(void)
 
 int
 qv_scope::bind_string(
-    qv_bind_string_format_t format,
+    qv_bind_string_flags_t flags,
     char **result
 ) {
+    *result = nullptr;
+
     hwloc_cpuset_t bitmap = nullptr;
     int rc = m_group->task()->bind_top(&bitmap);
     if (qvi_unlikely(rc != QV_SUCCESS)) return rc;
 
-    hwloc_topology_t topo = qvi_hwloc_get_topo_obj(m_group->hwloc());
-
-    rc = qvi_hwloc_bitmap_string(topo, bitmap, format, result);
+    rc = qvi_hwloc_bind_string(
+        m_group->hwloc(), bitmap, flags, result
+    );
     qvi_hwloc_bitmap_delete(&bitmap);
     return rc;
 }

--- a/src/qvi-scope.h
+++ b/src/qvi-scope.h
@@ -106,7 +106,7 @@ public:
 
     int
     bind_string(
-        qv_bind_string_format_t format,
+        qv_bind_string_flags_t flags,
         char **result
     );
 

--- a/tests/common-test-utils.h
+++ b/tests/common-test-utils.h
@@ -57,12 +57,12 @@ ctu_emit_task_bind(
     char const *ers = NULL;
     // Get new, current binding.
     char *binds = NULL;
-    int rc = qv_scope_bind_string(scope, QV_BIND_STRING_AS_LIST, &binds);
+    int rc = qv_scope_bind_string(scope, QV_BIND_STRING_LOGICAL, &binds);
     if (rc != QV_SUCCESS) {
         ers = "qv_bind_string() failed";
         ctu_panic("%s (rc=%s)", ers, qv_strerr(rc));
     }
-    printf("[%d] cpubind (physical) = %s\n", pid, binds);
+    printf("[%d] cpubind=%s\n", pid, binds);
     free(binds);
 }
 
@@ -121,7 +121,7 @@ ctu_bind_push(
     }
     // Get current binding.
     char *bind0s;
-    rc = qv_scope_bind_string(scope, QV_BIND_STRING_AS_LIST, &bind0s);
+    rc = qv_scope_bind_string(scope, QV_BIND_STRING_LOGICAL, &bind0s);
     if (rc != QV_SUCCESS) {
         ers = "qv_bind_string() failed";
         ctu_panic("%s (rc=%s)", ers, qv_strerr(rc));
@@ -137,7 +137,7 @@ ctu_bind_push(
 
     // Get new, current binding.
     char *bind1s;
-    rc = qv_scope_bind_string(scope, QV_BIND_STRING_AS_LIST, &bind1s);
+    rc = qv_scope_bind_string(scope, QV_BIND_STRING_LOGICAL, &bind1s);
     if (rc != QV_SUCCESS) {
         ers = "qv_bind_string() failed";
         ctu_panic("%s (rc=%s)", ers, qv_strerr(rc));
@@ -167,7 +167,7 @@ ctu_bind_pop(
     }
     // Get current binding.
     char *bind0s;
-    rc = qv_scope_bind_string(scope, QV_BIND_STRING_AS_LIST, &bind0s);
+    rc = qv_scope_bind_string(scope, QV_BIND_STRING_LOGICAL, &bind0s);
     if (rc != QV_SUCCESS) {
         ers = "qv_bind_string() failed";
         ctu_panic("%s (rc=%s)", ers, qv_strerr(rc));
@@ -182,7 +182,7 @@ ctu_bind_pop(
     }
     // Get new, current binding.
     char *bind1s;
-    rc = qv_scope_bind_string(scope, QV_BIND_STRING_AS_LIST, &bind1s);
+    rc = qv_scope_bind_string(scope, QV_BIND_STRING_LOGICAL, &bind1s);
     if (rc != QV_SUCCESS) {
         ers = "qv_bind_string() failed";
         ctu_panic("%s (rc=%s)", ers, qv_strerr(rc));
@@ -213,7 +213,7 @@ ctu_change_bind(
     }
     // Get current binding.
     char *bind0s;
-    rc = qv_scope_bind_string(scope, QV_BIND_STRING_AS_LIST, &bind0s);
+    rc = qv_scope_bind_string(scope, QV_BIND_STRING_LOGICAL, &bind0s);
     if (rc != QV_SUCCESS) {
         ers = "qv_bind_string() failed";
         ctu_panic("%s (rc=%s)", ers, qv_strerr(rc));
@@ -229,7 +229,7 @@ ctu_change_bind(
 
     // Get new, current binding.
     char *bind1s;
-    rc = qv_scope_bind_string(scope, QV_BIND_STRING_AS_LIST, &bind1s);
+    rc = qv_scope_bind_string(scope, QV_BIND_STRING_LOGICAL, &bind1s);
     if (rc != QV_SUCCESS) {
         ers = "qv_bind_string() failed";
         ctu_panic("%s (rc=%s)", ers, qv_strerr(rc));
@@ -243,7 +243,7 @@ ctu_change_bind(
     }
 
     char *bind2s;
-    rc = qv_scope_bind_string(scope, QV_BIND_STRING_AS_LIST, &bind2s);
+    rc = qv_scope_bind_string(scope, QV_BIND_STRING_LOGICAL, &bind2s);
     if (rc != QV_SUCCESS) {
         ers = "qv_bind_string() failed";
         ctu_panic("%s (rc=%s)", ers, qv_strerr(rc));

--- a/tests/internal/test-hwloc.c
+++ b/tests/internal/test-hwloc.c
@@ -208,7 +208,7 @@ main(void)
         ctu_panic("%s (rc=%s)", ers, qv_strerr(rc));
     }
 
-    rc = qvi_hwloc_bitmap_asprintf(NULL, bitmap, &binds);
+    rc = qvi_hwloc_bitmap_asprintf(bitmap, &binds);
     if (rc != QV_SUCCESS) {
         ers = "qvi_hwloc_bitmap_asprintf() failed";
         ctu_panic("%s (rc=%s)", ers, qv_strerr(rc));

--- a/tests/internal/test-rmi.cc
+++ b/tests/internal/test-rmi.cc
@@ -112,7 +112,7 @@ client(
     }
 
     char *res;
-    qvi_hwloc_bitmap_asprintf(NULL, bitmap, &res);
+    qvi_hwloc_bitmap_asprintf(bitmap, &res);
     printf("# [%d] cpubind = %s\n", who, res);
     hwloc_bitmap_free(bitmap);
     free(res);

--- a/tests/test-mpi-fortapi.f90
+++ b/tests/test-mpi-fortapi.f90
@@ -1,11 +1,3 @@
-!
-! Copyright (c) 2013-2024 Triad National Security, LLC
-!                         All rights reserved.
-!
-! This file is part of the quo-vadis project. See the LICENSE file at the
-! top-level directory of this distribution.
-!
-
 ! Does nothing useful. Just used to exercise the Fortran interface.
 
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
@@ -101,7 +93,7 @@ program mpi_fortapi
         error stop
     end if
 
-    call qv_scope_bind_string(sub_scope, QV_BIND_STRING_AS_LIST, bstr, info)
+    call qv_scope_bind_string(sub_scope, QV_BIND_STRING_LOGICAL, bstr, info)
     if (info .ne. QV_SUCCESS) then
         error stop
     end if

--- a/tests/test-mpi-phases.c
+++ b/tests/test-mpi-phases.c
@@ -95,7 +95,7 @@ main(
       printf("\n===Phase 1: Regular split===\n");
 
     char *binds;
-    rc = qv_scope_bind_string(base_scope, QV_BIND_STRING_AS_LIST, &binds);
+    rc = qv_scope_bind_string(base_scope, QV_BIND_STRING_LOGICAL, &binds);
     if (rc != QV_SUCCESS) {
         ers = "qv_bind_get_list_as_string() failed";
         ctu_panic("%s (rc=%s)", ers, qv_strerr(rc));
@@ -143,7 +143,7 @@ main(
     }
 
     /* Where did I end up? */
-    rc = qv_scope_bind_string(sub_scope, QV_BIND_STRING_AS_LIST, &binds);
+    rc = qv_scope_bind_string(sub_scope, QV_BIND_STRING_LOGICAL, &binds);
     if (rc != QV_SUCCESS) {
         ers = "qv_bind_get_list_as_string() failed";
         ctu_panic("%s (rc=%s)", ers, qv_strerr(rc));
@@ -186,7 +186,7 @@ main(
         ctu_panic("%s (rc=%s)", ers, qv_strerr(rc));
     }
 
-    rc = qv_scope_bind_string(base_scope, QV_BIND_STRING_AS_LIST, &binds);
+    rc = qv_scope_bind_string(base_scope, QV_BIND_STRING_LOGICAL, &binds);
     if (rc != QV_SUCCESS) {
         ers = "qv_bind_get_list_as_string() failed";
         ctu_panic("%s (rc=%s)", ers, qv_strerr(rc));
@@ -277,7 +277,7 @@ main(
     }
 
     /* Where did I end up? */
-    rc = qv_scope_bind_string(numa_scope, QV_BIND_STRING_AS_LIST, &binds);
+    rc = qv_scope_bind_string(numa_scope, QV_BIND_STRING_LOGICAL, &binds);
     if (rc != QV_SUCCESS) {
         ers = "qv_bind_get_list_as_string() failed";
         ctu_panic("%s (rc=%s)", ers, qv_strerr(rc));
@@ -316,7 +316,7 @@ main(
         ctu_panic("%s (rc=%s)", ers, qv_strerr(rc));
     }
 
-    rc = qv_scope_bind_string(base_scope, QV_BIND_STRING_AS_LIST, &binds);
+    rc = qv_scope_bind_string(base_scope, QV_BIND_STRING_LOGICAL, &binds);
     if (rc != QV_SUCCESS) {
         ers = "qv_bind_get_list_as_string() failed";
         ctu_panic("%s (rc=%s)", ers, qv_strerr(rc));
@@ -399,7 +399,7 @@ main(
     }
 
     /* Where did I end up? */
-    rc = qv_scope_bind_string(gpu_scope, QV_BIND_STRING_AS_LIST, &binds);
+    rc = qv_scope_bind_string(gpu_scope, QV_BIND_STRING_LOGICAL, &binds);
     if (rc != QV_SUCCESS) {
         ers = "qv_bind_get_list_as_string() failed";
         ctu_panic("%s (rc=%s)", ers, qv_strerr(rc));

--- a/tests/test-mpi-scope-create.c
+++ b/tests/test-mpi-scope-create.c
@@ -55,7 +55,7 @@ test_create_scope(
   }
 
   /* Where did I end up? */
-  rc = qv_scope_bind_string(core_scope, QV_BIND_STRING_AS_LIST, &binds);
+  rc = qv_scope_bind_string(core_scope, QV_BIND_STRING_LOGICAL, &binds);
   if (rc != QV_SUCCESS) {
     ers = "qv_bind_get_list_as_string() failed";
     ctu_panic("%s (rc=%s)", ers, qv_strerr(rc));
@@ -70,7 +70,7 @@ test_create_scope(
     ctu_panic("%s (rc=%s)", ers, qv_strerr(rc));
   }
 
-  rc = qv_scope_bind_string(scope, QV_BIND_STRING_AS_LIST, &binds);
+  rc = qv_scope_bind_string(scope, QV_BIND_STRING_LOGICAL, &binds);
   if (rc != QV_SUCCESS) {
     ers = "qv_bind_get_list_as_string() failed";
     ctu_panic("%s (rc=%s)", ers, qv_strerr(rc));
@@ -153,7 +153,7 @@ main(
     }
 
     char *binds;
-    rc = qv_scope_bind_string(base_scope, QV_BIND_STRING_AS_LIST, &binds);
+    rc = qv_scope_bind_string(base_scope, QV_BIND_STRING_LOGICAL, &binds);
     if (rc != QV_SUCCESS) {
         ers = "qv_bind_get_list_as_string() failed";
         ctu_panic("%s (rc=%s)", ers, qv_strerr(rc));
@@ -207,7 +207,7 @@ main(
     }
 
     /* Where did I end up? */
-    rc = qv_scope_bind_string(sub_scope, QV_BIND_STRING_AS_LIST, &binds);
+    rc = qv_scope_bind_string(sub_scope, QV_BIND_STRING_LOGICAL, &binds);
     if (rc != QV_SUCCESS) {
         ers = "qv_bind_get_list_as_string() failed";
         ctu_panic("%s (rc=%s)", ers, qv_strerr(rc));

--- a/tests/test-mpi-threads.c
+++ b/tests/test-mpi-threads.c
@@ -87,7 +87,7 @@ change_bind(
     }
 
     char *bind1s;
-    rc = qv_scope_bind_string(scope, QV_BIND_STRING_AS_LIST, &bind1s);
+    rc = qv_scope_bind_string(scope, QV_BIND_STRING_LOGICAL, &bind1s);
     if (rc != QV_SUCCESS) {
         ers = "qv_bind_string() failed";
         ctu_panic("%s (rc=%s)", ers, qv_strerr(rc));
@@ -102,7 +102,7 @@ change_bind(
     }
 
     char *bind2s;
-    rc = qv_scope_bind_string(scope, QV_BIND_STRING_AS_LIST, &bind2s);
+    rc = qv_scope_bind_string(scope, QV_BIND_STRING_LOGICAL, &bind2s);
     if (rc != QV_SUCCESS) {
         ers = "qv_bind_string() failed";
         ctu_panic("%s (rc=%s)", ers, qv_strerr(rc));
@@ -259,7 +259,7 @@ main(void)
       printf("[%d][%d] Number of PUS   in omp_self_scope is %d\n", wrank, tid, n_pus);
 
       char *binds;
-      rc = qv_bind_string(omp_ctx, QV_BIND_STRING_AS_LIST, &binds);
+      rc = qv_bind_string(omp_ctx, QV_BIND_STRING_LOGICAL, &binds);
       if (rc != QV_SUCCESS) {
         ers = "qv_bind_string() failed";
         ctu_panic("%s (rc=%s)", ers, qv_strerr(rc));

--- a/tests/test-omp.c
+++ b/tests/test-omp.c
@@ -22,7 +22,7 @@ emit_iter_info(
     char const *ers = NULL;
     char *binds;
     const int rc = qv_scope_bind_string(
-        sinfo->scope, QV_BIND_STRING_AS_LIST, &binds
+        sinfo->scope, QV_BIND_STRING_LOGICAL, &binds
     );
     if (rc != QV_SUCCESS) {
         ers = "qv_bind_string() failed";

--- a/tests/test-process-fortapi.f90
+++ b/tests/test-process-fortapi.f90
@@ -1,11 +1,3 @@
-!
-! Copyright (c) 2013-2024 Triad National Security, LLC
-!                         All rights reserved.
-!
-! This file is part of the quo-vadis project. See the LICENSE file at the
-! top-level directory of this distribution.
-!
-
 ! Does nothing useful. Just used to exercise the Fortran interface.
 
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
@@ -47,7 +39,7 @@ program process_fortapi
     end if
     print *, 'ncores', n_cores
 
-    call qv_scope_bind_string(scope_user, QV_BIND_STRING_AS_LIST, bstr, info)
+    call qv_scope_bind_string(scope_user, QV_BIND_STRING_LOGICAL, bstr, info)
     if (info .ne. QV_SUCCESS) then
         error stop
     end if

--- a/tests/test-progress-thread.c
+++ b/tests/test-progress-thread.c
@@ -37,7 +37,7 @@ void *thread_work(void *arg)
 
     char *binds;
     char const *ers = NULL;
-    int rc = qv_bind_string(ctx, QV_BIND_STRING_AS_LIST, &binds);
+    int rc = qv_bind_string(ctx, QV_BIND_STRING_LOGICAL, &binds);
 
     if (rc != QV_SUCCESS) {
         ers = "qv_bind_get_list_as_string() failed";
@@ -100,7 +100,7 @@ int main(int argc, char *argv[])
 
     /* Where did I end up? */
     char *binds;
-    rc = qv_scope_bind_string(task_scope, QV_BIND_STRING_AS_LIST, &binds);
+    rc = qv_scope_bind_string(task_scope, QV_BIND_STRING_LOGICAL, &binds);
     if (rc != QV_SUCCESS) {
         ers = "qv_bind_get_list_as_string() failed";
         ctu_panic("%s (rc=%s)", ers, qv_strerr(rc));
@@ -158,7 +158,7 @@ int main(int argc, char *argv[])
         ers = "qv_bind_push() failed";
         ctu_panic("%s (rc=%s)", ers, qv_strerr(rc));
     }
-    rc = qv_scope_bind_string(wk_scope, QV_BIND_STRING_AS_LIST, &binds);
+    rc = qv_scope_bind_string(wk_scope, QV_BIND_STRING_LOGICAL, &binds);
     if (rc != QV_SUCCESS) {
         ers = "qv_bind_get_list_as_string() failed";
         ctu_panic("%s (rc=%s)", ers, qv_strerr(rc));
@@ -177,7 +177,7 @@ int main(int argc, char *argv[])
         ers = "qv_bind_push() failed";
         ctu_panic("%s (rc=%s)", ers, qv_strerr(rc));
     }
-    rc = qv_scope_bind_string(ut_scope, QV_BIND_STRING_AS_LIST, &binds);
+    rc = qv_scope_bind_string(ut_scope, QV_BIND_STRING_LOGICAL, &binds);
     if (rc != QV_SUCCESS) {
         ers = "qv_bind_get_list_as_string() failed";
         ctu_panic("%s (rc=%s)", ers, qv_strerr(rc));


### PR DESCRIPTION
This commit allows users to specify logical, physical (OS), or both bind string listing types. This also does away with exposing a hex bind string format at the user interface.