### PR TITLE
Rename qv_scope_get_device_id() to qv_scope_device_id_get().

### DIFF
--- a/include/quo-vadis.h
+++ b/include/quo-vadis.h
@@ -194,6 +194,19 @@ qv_process_scope_get(
 /**
  *
  */
+// TODO(skg) Add to Fortran interface.
+int
+qv_scope_create(
+    qv_scope_t *scope,
+    qv_hw_obj_type_t type,
+    int nobjs,
+    qv_scope_create_hints_t hint,
+    qv_scope_t **subscope
+);
+
+/**
+ *
+ */
 int
 qv_scope_group_rank(
     qv_scope_t *scope,
@@ -219,12 +232,11 @@ qv_scope_nobjs(
     int *nobjs
 );
 
-// TODO(skg) Rename to qv_scope_device_id_get?
 /**
  *
  */
 int
-qv_scope_get_device_id(
+qv_scope_device_id_get(
     qv_scope_t *scope,
     qv_hw_obj_type_t dev_obj,
     int dev_index,
@@ -238,19 +250,6 @@ qv_scope_get_device_id(
 int
 qv_scope_barrier(
     qv_scope_t *scope
-);
-
-/**
- *
- */
-// TODO(skg) Add to Fortran interface.
-int
-qv_scope_create(
-    qv_scope_t *scope,
-    qv_hw_obj_type_t type,
-    int nobjs,
-    qv_scope_create_hints_t hint,
-    qv_scope_t **subscope
 );
 
 /**
@@ -279,14 +278,6 @@ qv_scope_split_at(
  *
  */
 int
-qv_scope_free(
-    qv_scope_t *scope
-);
-
-/**
- *
- */
-int
 qv_scope_bind_push(
     qv_scope_t *scope
 );
@@ -307,6 +298,14 @@ qv_scope_bind_string(
     qv_scope_t *scope,
     qv_bind_string_flags_t flags,
     char **str
+);
+
+/**
+ * Releases resources associated with the provided scope.
+ */
+int
+qv_scope_free(
+    qv_scope_t *scope
 );
 
 #ifdef __cplusplus

--- a/src/fortran/quo-vadisf.f90
+++ b/src/fortran/quo-vadisf.f90
@@ -214,10 +214,10 @@ interface
     end function qv_scope_barrier_c
 
     integer(c_int) &
-    function qv_scope_get_device_id_c( &
+    function qv_scope_device_id_get_c( &
         scope, dev_obj, i, id_type, dev_id &
     ) &
-        bind(c, name='qv_scope_get_device_id')
+        bind(c, name='qv_scope_device_id_get')
         use, intrinsic :: iso_c_binding, only: c_ptr, c_int
         implicit none
         type(c_ptr), value :: scope
@@ -225,7 +225,7 @@ interface
         integer(c_int), value :: i
         integer(c_int), value :: id_type
         type(c_ptr), intent(out) :: dev_id
-    end function qv_scope_get_device_id_c
+    end function qv_scope_device_id_get_c
 
     integer(c_int) &
     function qv_scope_bind_push_c(scope) &
@@ -367,7 +367,7 @@ contains
         info = qv_scope_barrier_c(scope)
     end subroutine qv_scope_barrier
 
-    subroutine qv_scope_get_device_id( &
+    subroutine qv_scope_device_id_get( &
         scope, dev_obj, i, id_type, dev_id, info &
     )
         use, intrinsic :: iso_c_binding, only: c_ptr, c_int
@@ -383,7 +383,7 @@ contains
         integer(c_size_t) :: strlen
         character, pointer, dimension(:) :: fstrp
 
-        info = qv_scope_get_device_id_c( &
+        info = qv_scope_device_id_get_c( &
             scope, dev_obj, i, id_type, cstr &
         )
         ! Now deal with the string
@@ -392,7 +392,7 @@ contains
         allocate(character(strlen) :: dev_id(1))
         dev_id = fstrp
         call qvif_free_c(cstr)
-    end subroutine qv_scope_get_device_id
+    end subroutine qv_scope_device_id_get
 
     subroutine qv_scope_bind_push(scope, info)
         use, intrinsic :: iso_c_binding, only: c_ptr, c_int

--- a/src/quo-vadis.cc
+++ b/src/quo-vadis.cc
@@ -234,7 +234,7 @@ qv_scope_split_at(
 }
 
 int
-qv_scope_get_device_id(
+qv_scope_device_id_get(
     qv_scope_t *scope,
     qv_hw_obj_type_t dev_obj,
     int dev_index,

--- a/src/qvi-group-thread.h
+++ b/src/qvi-group-thread.h
@@ -57,7 +57,7 @@ public:
         std::lock_guard<std::mutex> guard(m_mutex);
 
         size_t myindex = 0;
-        int rc = m_tid2index.get(mytid, myindex);
+        const int rc = m_tid2index.get(mytid, myindex);
 
         switch (rc) {
             // Found my index.

--- a/src/qvi-utils.h
+++ b/src/qvi-utils.h
@@ -56,7 +56,6 @@ private:
         Key,
         typename std::list<std::pair<Key, Value>
     >::iterator> m_cache_map;
-
 public:
     /** Constructor. */
     qvi_lru_cache(

--- a/tests/test-mpi-fortapi.f90
+++ b/tests/test-mpi-fortapi.f90
@@ -112,7 +112,7 @@ program mpi_fortapi
     print *, 'ngpu', n_gpu
 
     do n = 0, n_gpu - 1
-        call qv_scope_get_device_id( &
+        call qv_scope_device_id_get( &
             scope_user, QV_HW_OBJ_GPU, n, &
             QV_DEVICE_ID_PCI_BUS_ID, dev_pci, info &
         )

--- a/tests/test-mpi-getdev.c
+++ b/tests/test-mpi-getdev.c
@@ -37,7 +37,7 @@ emit_gpu_info(
     for (int i = 0; i < ngpus; ++i) {
         for (unsigned j = 0; j < ndevids; ++j) {
             char *devids = NULL;
-            int rc = qv_scope_get_device_id(
+            int rc = qv_scope_device_id_get(
                 scope,
                 QV_HW_OBJ_GPU,
                 i,
@@ -45,7 +45,7 @@ emit_gpu_info(
                 &devids
             );
             if (rc != QV_SUCCESS) {
-                const char *ers = "qv_scope_get_device_id() failed";
+                const char *ers = "qv_scope_device_id_get() failed";
                 ctu_panic("%s (rc=%s)", ers, qv_strerr(rc));
             }
             printf("# Device %u %s = %s\n", i, devnts[j].name, devids);

--- a/tests/test-mpi-phases.c
+++ b/tests/test-mpi-phases.c
@@ -171,7 +171,7 @@ main(
 
     char *gpu;
     for (int i = 0; i < ngpus; i++) {
-        qv_scope_get_device_id(sub_scope, QV_HW_OBJ_GPU, i, QV_DEVICE_ID_PCI_BUS_ID, &gpu);
+        qv_scope_device_id_get(sub_scope, QV_HW_OBJ_GPU, i, QV_DEVICE_ID_PCI_BUS_ID, &gpu);
         printf("GPU %d PCI Bus ID = %s\n", i, gpu);
         //cudaDeviceGetByPCIBusId(&dev, gpu);
         //cudaSetDevice(dev);
@@ -409,7 +409,7 @@ main(
     free(binds);
 
     for (int i=0; i<my_ngpus; i++) {
-      qv_scope_get_device_id(gpu_scope, QV_HW_OBJ_GPU,
+      qv_scope_device_id_get(gpu_scope, QV_HW_OBJ_GPU,
               i, QV_DEVICE_ID_PCI_BUS_ID, &gpu);
       printf("   [%d] GPU %d PCI Bus ID = %s\n", wrank, i, gpu);
       free(gpu);

--- a/tests/test-process-fortapi.f90
+++ b/tests/test-process-fortapi.f90
@@ -53,7 +53,7 @@ program process_fortapi
     print *, 'ngpu', n_gpu
 
     do n = 0, n_gpu - 1
-        call qv_scope_get_device_id( &
+        call qv_scope_device_id_get( &
             scope_user, QV_HW_OBJ_GPU, n, &
             QV_DEVICE_ID_PCI_BUS_ID, dev_pci, info &
         )


### PR DESCRIPTION
This appears to be more consistent with our public naming convention.