### PR TITLE
Add client-side connection timeout.

### DIFF
--- a/include/quo-vadis.h
+++ b/include/quo-vadis.h
@@ -56,13 +56,11 @@ enum {
     QV_ERR_SYS,
     QV_ERR_OOR,
     QV_ERR_INVLD_ARG,
-    QV_ERR_CALL_BEFORE_INIT,
     QV_ERR_HWLOC,
     QV_ERR_MPI,
     QV_ERR_MSG,
     QV_ERR_RPC,
     QV_ERR_NOT_SUPPORTED,
-    QV_ERR_POP,
     QV_ERR_NOT_FOUND,
     QV_ERR_SPLIT,
     /** Resources unavailable. */

--- a/src/quo-vadisd.cc
+++ b/src/quo-vadisd.cc
@@ -108,7 +108,7 @@ rmi_config(
 
     int rc = qvi_url(ctx.rmic.url);
     if (rc != QV_SUCCESS) {
-        qvi_panic_log_error(qvi_conn_ers());
+        qvi_panic_log_error(qvi_conn_env_ers());
         return;
     }
 

--- a/src/qvi-task.cc
+++ b/src/qvi-task.cc
@@ -28,12 +28,22 @@ int
 qvi_task::m_connect_to_server(void)
 {
     std::string url;
-    const int rc = qvi_url(url);
+    int rc = qvi_url(url);
     if (qvi_unlikely(rc != QV_SUCCESS)) {
-        qvi_log_error("{}", qvi_conn_ers());
+        qvi_log_error("{}", qvi_conn_env_ers());
         return rc;
     }
-    return m_rmi->connect(url);
+
+    rc = m_rmi->connect(url);
+    if (qvi_unlikely(rc == QV_RES_UNAVAILABLE)) {
+        const std::string msg =
+            "\n\n#############################################\n"
+            "# A client could not connect to its server.\n"
+            "# Ensure quo-vadisd is running and reachable."
+            "\n#############################################\n\n";
+        qvi_log_error("{}", msg);
+    }
+    return rc;
 }
 
 int

--- a/src/qvi-utils.cc
+++ b/src/qvi-utils.cc
@@ -33,13 +33,11 @@ static const std::map<uint_t, std::string> qvi_rc2str = {
     {QV_ERR_SYS, "System error"},
     {QV_ERR_OOR, "Out of resources"},
     {QV_ERR_INVLD_ARG, "Invalid argument"},
-    {QV_ERR_CALL_BEFORE_INIT, "Call before initialization"},
     {QV_ERR_HWLOC, "Hardware locality error"},
     {QV_ERR_MPI, "MPI error"},
     {QV_ERR_MSG, "Internal message error"},
     {QV_ERR_RPC, "Remote procedure call error"},
     {QV_ERR_NOT_SUPPORTED, "Operation not supported"},
-    {QV_ERR_POP, "Pop operation error"},
     {QV_ERR_NOT_FOUND, "Not found"},
     {QV_ERR_SPLIT, "Split error"},
     {QV_RES_UNAVAILABLE, "Resources unavailable"}
@@ -105,14 +103,14 @@ qvi_url(
     return QV_SUCCESS;
 }
 
-cstr_t
-qvi_conn_ers(void)
+std::string
+qvi_conn_env_ers(void)
 {
     static const std::string msg = "Cannot determine connection information. "
                                    "Please make sure that the following "
                                    "environment variable is set to an unused "
                                    "port number: " + std::string(QVI_ENV_PORT);
-    return msg.c_str();
+    return msg;
 }
 
 std::string

--- a/src/qvi-utils.h
+++ b/src/qvi-utils.h
@@ -213,8 +213,8 @@ qvi_access(
 /**
  *
  */
-cstr_t
-qvi_conn_ers(void);
+std::string
+qvi_conn_env_ers(void);
 
 /**
  *


### PR DESCRIPTION
Add a 5-second client/server timeout for data exchanges. This also servers as a way to avoid long hangs when a client is started without an accompanying daemon.