### PR TITLE
Implement client-side auto discovery.

### DIFF
--- a/src/qvi-common.h
+++ b/src/qvi-common.h
@@ -50,12 +50,15 @@
 #include "qvi-log.h"
 #include <chrono>
 #include <csignal>
+#include <filesystem>
 #include <list>
 #include <map>
 #include <mutex>
 #include <condition_variable>
 #include <new>
 #include <numeric>
+#include <random>
+#include <regex>
 #include <set>
 #include <stack>
 #include <stdexcept>

--- a/src/qvi-rmi.h
+++ b/src/qvi-rmi.h
@@ -253,11 +253,16 @@ public:
     /** Returns a pointer to the client's hwloc instance. */
     qvi_hwloc &
     hwloc(void);
+    /** Discovers server connection information. */
+    int
+    discover(
+        int &portno
+    );
     /** Connects a client to to the server specified by the provided info. */
     int
     connect(
         const std::string &url,
-        const int &portno
+        const int portno
     );
     /** Returns the current cpuset of the provided PID. */
     int
@@ -329,6 +334,9 @@ qvi_rmi_get_url(
  */
 std::string
 qvi_rmi_conn_env_ers(void);
+
+std::string
+qvi_rmi_discovery_ers(void);
 
 #endif
 

--- a/src/qvi-task.cc
+++ b/src/qvi-task.cc
@@ -38,16 +38,23 @@ qvi_task::hwloc(void)
 int
 qvi_task::m_connect_to_server(void)
 {
-    std::string url;
+    // Discover the server's port number.
     int portno = QVI_RMI_PORT_UNSET;
-    int rc = qvi_rmi_get_url(url, portno);
+    int rc = m_rmi.discover(portno);
+    if (qvi_unlikely(rc != QV_SUCCESS)) {
+        qvi_log_error("{}", qvi_rmi_discovery_ers());
+        return QV_RES_UNAVAILABLE;
+    }
+
+    std::string url;
+    rc = qvi_rmi_get_url(url, portno);
     if (qvi_unlikely(rc != QV_SUCCESS)) {
         qvi_log_error("{}", qvi_rmi_conn_env_ers());
         return QV_RES_UNAVAILABLE;
     }
 
     rc = m_rmi.connect(url, portno);
-    if (qvi_unlikely(rc == QV_RES_UNAVAILABLE)) {
+    if (qvi_unlikely(rc != QV_SUCCESS)) {
         const std::string msg =
             "\n\n#############################################\n"
             "# A client could not communicate with its server.\n"

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -12,6 +12,10 @@
 
 ################################################################################
 ################################################################################
+# Used to test QVD with specified port and no QV_PORT.
+set(QV_START_QVD_WPORT "../src/quo-vadisd --no-daemonize --port 55999")
+set(QV_START_QVD_WENV "../src/quo-vadisd --no-daemonize")
+
 add_executable(
     test-process-scopes
     test-process-scopes.c
@@ -26,8 +30,8 @@ add_test(
     NAME
       process-scopes
     COMMAND
-      bash -c "export QV_PORT=\"55999\" && \
-      ( ${CMAKE_SOURCE_DIR}/tests/exec-timeout.sh 5 ../src/quo-vadisd --no-daemonize & ) && \
+      bash -c "
+      ( ${CMAKE_SOURCE_DIR}/tests/exec-timeout.sh 5 ${QV_START_QVD_WPORT} & ) && \
         ${CMAKE_CURRENT_BINARY_DIR}/test-process-scopes"
 )
 
@@ -64,7 +68,7 @@ if (OPENMP_FOUND)
           omp
         COMMAND
           bash -c "export QV_PORT=\"55999\" && \
-          ( ${CMAKE_SOURCE_DIR}/tests/exec-timeout.sh 5 ../src/quo-vadisd --no-daemonize & ) && \
+          ( ${CMAKE_SOURCE_DIR}/tests/exec-timeout.sh 5 ${QV_START_QVD_WENV} & ) && \
             ${CMAKE_CURRENT_BINARY_DIR}/test-omp"
     )
 
@@ -192,8 +196,8 @@ if(MPI_FOUND)
         NAME
           mpi-api
         COMMAND
-          bash -c "export QV_PORT=\"55999\" && \
-          ( ${CMAKE_SOURCE_DIR}/tests/exec-timeout.sh 5 ../src/quo-vadisd --no-daemonize & ) && \
+          bash -c "
+          ( ${CMAKE_SOURCE_DIR}/tests/exec-timeout.sh 5 ${QV_START_QVD_WPORT} & ) && \
             ${MPIEXEC_EXECUTABLE} \
             ${MPIEXEC_NUMPROC_FLAG} \
             ${MPIEXEC_MAX_NUMPROCS} \
@@ -205,7 +209,7 @@ if(MPI_FOUND)
           mpi-scopes
         COMMAND
           bash -c "export QV_PORT=\"55999\" && \
-          ( ${CMAKE_SOURCE_DIR}/tests/exec-timeout.sh 5 ../src/quo-vadisd --no-daemonize & ) && \
+          ( ${CMAKE_SOURCE_DIR}/tests/exec-timeout.sh 5 ${QV_START_QVD_WENV} & ) && \
             ${MPIEXEC_EXECUTABLE} \
             ${MPIEXEC_NUMPROC_FLAG} \
             ${MPIEXEC_MAX_NUMPROCS} \
@@ -268,8 +272,8 @@ if(QV_FORTRAN_HAPPY)
         NAME
           process-fortapi
         COMMAND
-          bash -c "export QV_PORT=\"55999\" && \
-          ( ${CMAKE_SOURCE_DIR}/tests/exec-timeout.sh 5 ../src/quo-vadisd --no-daemonize & ) && \
+          bash -c "
+          ( ${CMAKE_SOURCE_DIR}/tests/exec-timeout.sh 5 ${QV_START_QVD_WPORT} & ) && \
           ${CMAKE_CURRENT_BINARY_DIR}/test-process-fortapi"
     )
 


### PR DESCRIPTION
Clients now automatically discover connection information from a session directory created by the server. The session directory is rooted at the tmp directory determined by qvi_tmpdir().

Clients now ignore QV_PORT. quo-vadisd requires QV_PORT only when --port [PORTNO] is not provided.