### PR TITLE
Add initial cut of automatic daemon startup for MPI jobs.

### DIFF
--- a/src/qvi-common.h
+++ b/src/qvi-common.h
@@ -84,6 +84,10 @@ struct qvi_hwpool;
 struct qvi_task;
 
 // Constants
+/** Unset port number constant. */
+const int QVI_PORT_UNSET = -1;
+/** Port environment variable string. */
+static const std::string QVI_ENV_PORT = "QV_PORT";
 static const std::string QVI_ENV_TMPDIR = "QV_TMPDIR";
 static const std::string QVI_ENV_VEXCEPT = "QV_VEXCEPT";
 
@@ -98,7 +102,7 @@ public:
         const std::string& message,
         int rc
     ) : std::runtime_error(message)
-      , m_rc(rc) {}
+      , m_rc(rc) { }
 
     int
     rc(void) const

--- a/src/qvi-group-mpi.cc
+++ b/src/qvi-group-mpi.cc
@@ -15,7 +15,7 @@
  */
 
 #include "qvi-group-mpi.h"
-#include "qvi-task.h" // IWYU pragma: keep
+#include "qvi-task.h"
 #include "qvi-utils.h"
 
 qvi_group_mpi::qvi_group_mpi(

--- a/src/qvi-rmi.h
+++ b/src/qvi-rmi.h
@@ -23,9 +23,6 @@
 #include "qvi-hwpool.h"
 #include "zmq.h"
 
-/** Unset port number constant. */
-const int QVI_RMI_PORT_UNSET = -1;
-
 struct qvi_rmi_msg_header;
 struct qvi_rmi_server;
 
@@ -57,7 +54,7 @@ struct qvi_rmi_config {
     /** Connection URL. */
     std::string url;
     /** Connection port number. */
-    int portno = QVI_RMI_PORT_UNSET;
+    int portno = QVI_PORT_UNSET;
     /** Path to hardware topology file. */
     std::string hwtopo_path;
 };
@@ -254,7 +251,7 @@ public:
     qvi_hwloc &
     hwloc(void);
     /** Discovers server connection information. */
-    int
+    static int
     discover(
         int &portno
     );
@@ -319,7 +316,7 @@ public:
 };
 
 /**
- * Returns a connection URL. When called with a portno of QVI_RMI_PORT_UNSET,
+ * Returns a connection URL. When called with a portno of QVI_COMM_PORT_UNSET,
  * then a valid portno is determined via an environment variable and returned.
  * If portno is set, then a URL is generated based on the provided port number.
  */
@@ -335,6 +332,9 @@ qvi_rmi_get_url(
 std::string
 qvi_rmi_conn_env_ers(void);
 
+/**
+ *
+ */
 std::string
 qvi_rmi_discovery_ers(void);
 

--- a/src/qvi-task.cc
+++ b/src/qvi-task.cc
@@ -39,8 +39,8 @@ int
 qvi_task::m_connect_to_server(void)
 {
     // Discover the server's port number.
-    int portno = QVI_RMI_PORT_UNSET;
-    int rc = m_rmi.discover(portno);
+    int portno = QVI_PORT_UNSET;
+    int rc = qvi_rmi_client::discover(portno);
     if (qvi_unlikely(rc != QV_SUCCESS)) {
         qvi_log_error("{}", qvi_rmi_discovery_ers());
         return QV_RES_UNAVAILABLE;

--- a/src/qvi-utils.h
+++ b/src/qvi-utils.h
@@ -186,12 +186,6 @@ qvi_copy(
 }
 
 /**
- *
- */
-int
-qvi_start_qvd(void);
-
-/**
  * See gettid(2) for details.
  */
 static inline pid_t
@@ -249,6 +243,11 @@ qvi_file_size(
     size_t *size
 );
 
+int
+qvi_port_from_env(
+    int &portno
+);
+
 /**
  * Cantor pairing function.
  */
@@ -256,6 +255,25 @@ int64_t
 qvi_cantor_pairing(
     int a,
     int b
+);
+
+bool
+qvi_session_exists(
+    int portno
+);
+
+int
+qvi_session_discover(
+    uint_t max_timeout_in_ms,
+    int &portno
+);
+
+/**
+ *
+ */
+int
+qvi_start_qvd(
+    int portno
 );
 
 #endif


### PR DESCRIPTION
This commit adds support for automatic quo-vadisd startup across the nodes in a given job.

If QV_PORT is set, then we try to use that port across the nodes. If unset, then we use a default port for the daemon. For automatic startup to work, quo-vadisd must be in PATH. Manual daemon startup is still supported.