### PR TITLE
Update auto daemon discovery.

### DIFF
--- a/src/qvi-common.h
+++ b/src/qvi-common.h
@@ -87,11 +87,13 @@ struct qvi_task;
 // Constants
 /** Unset port number constant. */
 const int QVI_PORT_UNSET = -1;
-/** Port environment variable string. */
+/** Name of the Quo Vadis daemon. */
+static const std::string QVI_DAEMON_NAME = "quo-vadisd";
+/** Port environment variable name. */
 static const std::string QVI_ENV_PORT = "QV_PORT";
-/** Temporary directory environment variable string. */
+/** Temporary directory environment variable name. */
 static const std::string QVI_ENV_TMPDIR = "QV_TMPDIR";
-/** Verbose exceptions environment variable string. */
+/** Verbose exceptions environment variable name. */
 static const std::string QVI_ENV_VEXCEPT = "QV_VEXCEPT";
 
 /**

--- a/src/qvi-hwloc.cc
+++ b/src/qvi-hwloc.cc
@@ -140,13 +140,11 @@ set_visdev_id(
     return QV_SUCCESS;
 }
 
-static int
+static std::string
 topo_fname(
-    const std::string &base,
-    std::string &name
+    const std::string &base
 ) {
-    name = base + "/hwtopo.xml";
-    return QV_SUCCESS;
+    return base + "/hwtopo." + std::to_string(getpid()) + ".xml";
 }
 
 void
@@ -158,7 +156,7 @@ qvi_hwloc::bitmap_debug(
     qvi_unused(msg);
 #endif
     if (!cpuset) throw qvi_runtime_error(QV_ERR_INTERNAL);
-    qvi_log_debug("{} CPUSET={}", msg, qvi_hwloc::bitmap_string(cpuset));
+    qvi_log_debug("{} BITMAP={}", msg, qvi_hwloc::bitmap_string(cpuset));
 }
 
 int
@@ -433,13 +431,7 @@ qvi_hwloc::topology_export(
             break;
         }
 
-        qvrc = topo_fname(base_path, m_topo_file);
-        if (qvi_unlikely(qvrc != QV_SUCCESS)) {
-            ers = "topo_fname() failed";
-            break;
-        }
-
-        path = m_topo_file;
+        path = m_topo_file = topo_fname(base_path);
 
         qvrc = s_topo_fopen(m_topo_file.c_str(), &fd);
         if (qvi_unlikely(qvrc != QV_SUCCESS)) {

--- a/src/qvi-mpi.cc
+++ b/src/qvi-mpi.cc
@@ -268,7 +268,6 @@ qvi_mpi::m_create_admin_comms(void)
     return QV_SUCCESS;
 }
 
-
 int
 qvi_mpi::get_portno_from_env(
     const qvi_mpi_comm &comm,
@@ -292,9 +291,8 @@ qvi_mpi::get_portno_from_env(
             break;
         }
         if (anyset) {
-            int envport = QVI_PORT_UNSET;
             // If this fails, envport is set to QVI_COMM_PORT_UNSET.
-            (void)qvi_port_from_env(envport);
+            int envport = qvi_port_from_env();
 
             std::vector<int> portnos(comm.m_size);
             mpirc = MPI_Allgather(
@@ -334,18 +332,19 @@ qvi_mpi::m_start_daemons(void)
         // Try to use the requested port.
         if (portno != QVI_PORT_UNSET) {
             // If there is an active session using the given port, use it.
-            if (qvi_session_exists(portno)) break;
+            rc = qvi_session_discover(16, portno);
+            if (rc == QV_SUCCESS) break;
             // Else start up the daemon using the requested port.
-            rc = qvi_start_qvd(portno);
+            rc = qvi_start_quo_vadisd(portno);
             // Done!
             break;
         }
         // No port requested, so try to discover one.
-        rc = qvi_session_discover(10, portno);
+        rc = qvi_session_discover(16, portno);
         // Found one, so use it.
         if (rc == QV_SUCCESS) break;
         // Else, start up the daemon using our default port number.
-        rc = qvi_start_qvd(57550);
+        rc = qvi_start_quo_vadisd(57550);
     } while (false);
     // See if any errors happened above, but all barrier to avoid hangs.
     if (qvi_unlikely(rc != QV_SUCCESS)) ret = rc;

--- a/src/qvi-utils.h
+++ b/src/qvi-utils.h
@@ -216,7 +216,6 @@ qvi_access(
 int
 qvi_stoi(
     const std::string &str,
-    int &maybe_result,
     int base = 10
 );
 
@@ -244,9 +243,7 @@ qvi_file_size(
 );
 
 int
-qvi_port_from_env(
-    int &portno
-);
+qvi_port_from_env(void);
 
 /**
  * Cantor pairing function.
@@ -255,11 +252,6 @@ int64_t
 qvi_cantor_pairing(
     int a,
     int b
-);
-
-bool
-qvi_session_exists(
-    int portno
 );
 
 int
@@ -272,7 +264,7 @@ qvi_session_discover(
  *
  */
 int
-qvi_start_qvd(
+qvi_start_quo_vadisd(
     int portno
 );
 
@@ -295,6 +287,10 @@ qvi_pid_cmdline(
     std::vector<std::string> &argv
 );
 
+/**
+ * Returns a vector of environment variable pairs
+ * used when the provided PID was started.
+ */
 int
 qvi_pid_envvars(
     pid_t pid,


### PR DESCRIPTION
Some parallel launchers such as srun kill off forked processes after a run. This results in orphaned session directories. The implication is that cannot use the existence of a session directory as a reliable marker. Instead inspect /proc for relevant information.