### PR TITLE
Improve affinity-preserving mapper with cleanups.

### DIFF
--- a/src/qvi-hwloc.cc
+++ b/src/qvi-hwloc.cc
@@ -178,12 +178,12 @@ qvi_hwloc::obj_res_class(
         case(QV_HW_OBJ_L4CACHE):
         case(QV_HW_OBJ_L5CACHE):
         case(QV_HW_OBJ_NUMANODE):
-            return QVI_HWLOC_RES_HOST;
+            return QVI_HWLOC_RES_CLASS_HOST;
         case(QV_HW_OBJ_GPU):
         case(QV_HW_OBJ_NIC):
-            return QVI_HWLOC_RES_DEV;
+            return QVI_HWLOC_RES_CLASS_DEV;
         case(QV_HW_OBJ_LAST):
-            return QVI_HWLOC_RES_LAST;
+            return QVI_HWLOC_RES_CLASS_LAST;
         [[unlikely]] default:
             // This is likely an internal development error.
             throw qvi_runtime_error(QV_ERR_INTERNAL);
@@ -794,8 +794,6 @@ qvi_hwloc::m_set_device_affinity_by_pci_bus_id(
     return QV_SUCCESS;
 }
 
-// TODO(skg) Was a high-speed network interface found? If so, use it, else use
-// other network interfaces.
 int
 qvi_hwloc::m_discover_devices(void)
 {

--- a/src/qvi-hwloc.h
+++ b/src/qvi-hwloc.h
@@ -50,9 +50,9 @@ const qvi_hwloc_flags_t QVI_HWLOC_TOPO_MASK = 0x0000000000000003LL;
 
 /** Internal resource type identifiers. */
 enum qvi_hwloc_res_class {
-    QVI_HWLOC_RES_HOST = 0,
-    QVI_HWLOC_RES_DEV,
-    QVI_HWLOC_RES_LAST
+    QVI_HWLOC_RES_CLASS_HOST = 0,
+    QVI_HWLOC_RES_CLASS_DEV,
+    QVI_HWLOC_RES_CLASS_LAST
 };
 
 struct qvi_hwloc {

--- a/src/qvi-hwpool.cc
+++ b/src/qvi-hwpool.cc
@@ -132,7 +132,7 @@ qvi_hwpool::device_affinities(
     qv_hw_obj_type_t obj_type
 ) const {
     switch (qvi_hwloc::obj_res_class(obj_type)) {
-        case QVI_HWLOC_RES_DEV: {
+        case QVI_HWLOC_RES_CLASS_DEV: {
             std::vector<qvi_hwloc_bitmap> result;
             for (const auto &dev : devices(obj_type)) {
                 result.emplace_back(dev.get()->affinity());
@@ -150,7 +150,7 @@ qvi_hwpool::nobjects(
     qv_hw_obj_type_t obj_type
 ) const {
     switch (qvi_hwloc::obj_res_class(obj_type)) {
-        case QVI_HWLOC_RES_HOST: {
+        case QVI_HWLOC_RES_CLASS_HOST: {
             size_t result;
             const int rc = hwloc.get_nobjs_in_cpuset(
                 obj_type, m_cpu.affinity().cdata(), result

--- a/src/qvi-hwsplit.cc
+++ b/src/qvi-hwsplit.cc
@@ -203,14 +203,14 @@ qvi_hwsplit::m_primary_cpuset_for_split(
         // Were we provided a real resource type that we have to split? Or was
         // QV_HW_OBJ_LAST instead provided to indicate that we were called from
         // a split() context.
-        case QVI_HWLOC_RES_LAST:
+        case QVI_HWLOC_RES_CLASS_LAST:
             // Pick PUs as the host resource, since this is
             // the atomic unit at which host resources are split.
             real_type = QV_HW_OBJ_PU;
             // Intentionally fall through.
-        case QVI_HWLOC_RES_HOST:
+        case QVI_HWLOC_RES_CLASS_HOST:
             return {real_type, m_base_hwpool.cpuset()};
-        case QVI_HWLOC_RES_DEV: {
+        case QVI_HWLOC_RES_CLASS_DEV: {
             // The cpuset will be the union over the devices affinities.
             qvi_hwloc_bitmap result;
             for (const auto &dev : m_base_hwpool.devices(real_type)) {

--- a/src/qvi-map.cc
+++ b/src/qvi-map.cc
@@ -212,13 +212,13 @@ solve_ap_mapping(
     const qvi_map_t &affinities
 ) {
     // Calculate max slots per destination.
-    const size_t max_slots_per_dest = qvi_maxiperk(n, m);
+    const size_t slots_per_dest = qvi_maxiperk(n, m);
     // Node layout:
     // 0: Super source
     // 1...n: Source nodes
     // n+1...n+(m*max_slots_per_dest): Destination slot nodes
     // last: Super sink
-    const size_t total_slot_nodes = m * max_slots_per_dest;
+    const size_t total_slot_nodes = m * slots_per_dest;
     const int super_source = 0;
     const int super_sink = static_cast<int>(1 + n + total_slot_nodes);
     const int total_nodes = super_sink + 1;
@@ -228,42 +228,50 @@ solve_ap_mapping(
     for (size_t i = 0; i < n; ++i) {
         mcmf.add_edge(super_source, 1 + i, 1, 0);
     }
+    // Penalty for using later slots.
+    const int64_t slot_penalty = 100000LL;
+    // High penalty for no-affinity (zero affinity) destinations.
+    const int64_t zaff_penalty = 10000000LL;
     // Edge 2: Source nodes-->destination slot nodes
     //         (capacity 1, progressive cost).
     // Cost structure:
-    // 1. Progressive penalty based on slot number
-    //    (strongly prefer first slots).
-    // 2. Small tie-breaker based on destination number
-    //    (prefer lower-numbered destinations).
+    // 1. Progressive penalty based on slot number:
+    //    strongly prefer first slots.
+    // 2. Small tie-breaker based on destination number:
+    //    prefer lower-numbered destinations.
+    // 3. Huge penalty for non-affinity destinations:
+    //    but still possible as fallback.
     for (size_t src = 0; src < n; ++src) {
         const auto it = affinities.find(src);
         std::set<size_t> src_affinities;
         if (it != affinities.end()) {
             src_affinities = it->second;
         }
-
-        for (size_t dst : src_affinities) {
+        // If affinity set is empty, treat it as "no preference":
+        // allow any destination with low cost.
+        if (src_affinities.empty()) {
+            for (size_t dst = 0; dst < m; ++dst) {
+                src_affinities.insert(dst);
+            }
+        }
+        // Connect to ALL destinations, but use different costs.
+        for (size_t dst = 0; dst < m; ++dst) {
+            const bool is_preferred = src_affinities.count(dst) > 0;
             // Connect source to all slots of this destination.
-            for (size_t slot = 0; slot < max_slots_per_dest; ++slot) {
-                const int slot_node = 1 + n + dst * max_slots_per_dest + slot;
-                // Progressive cost model:
-                // - Base cost: 100000 per slot:
-                //   strongly penalize using later slots.
-                // - Tie-breaker: +dst:
-                //   prefer lower-numbered destinations when slots are equal.
-                const int64_t progressive_penalty = 100000LL * slot;
-                // Small preference for lower destination numbers.
-                const int64_t dst_tiebreaker = dst;
-                const int64_t cost = progressive_penalty + dst_tiebreaker;
-
+            for (size_t slot = 0; slot < slots_per_dest; ++slot) {
+                const int slot_node = 1 + n + dst * slots_per_dest + slot;
+                const int64_t prog_penalty = slot_penalty * slot;
+                const int64_t dest_tiebrkr = dst;
+                const int64_t aff_penalty = is_preferred ? 0 : zaff_penalty;
+                const int64_t cost = aff_penalty + prog_penalty + dest_tiebrkr;
                 mcmf.add_edge(1 + src, slot_node, 1, cost);
             }
         }
     }
     // Edge 3: Destination slot nodes-->super sink (capacity 1, cost 0).
     for (size_t dst = 0; dst < m; ++dst) {
-        for (size_t slot = 0; slot < max_slots_per_dest; ++slot) {
-            const int slot_node = 1 + n + dst * max_slots_per_dest + slot;
+        for (size_t slot = 0; slot < slots_per_dest; ++slot) {
+            const int slot_node = 1 + n + dst * slots_per_dest + slot;
             mcmf.add_edge(slot_node, super_sink, 1, 0);
         }
     }
@@ -286,7 +294,7 @@ solve_ap_mapping(
                 slot_node < static_cast<int>(1 + n + total_slot_nodes) &&
                 edge.flow > 0) {
                 const size_t slot_idx = slot_node - (1 + n);
-                const size_t dst = slot_idx / max_slots_per_dest;
+                const size_t dst = slot_idx / slots_per_dest;
                 result[src].insert(dst);
             }
         }


### PR DESCRIPTION
Improve the MCMF model to better handle mixed affinity inputs. This fixes mapping failures that occur when heterogeneous source/destination affinities are provided as input.