### PR TITLE
Improve common testing infrastructure.

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -16,6 +16,26 @@
 set(QV_START_QVD_WPORT "../src/quo-vadisd --no-daemonize --port 55999")
 set(QV_START_QVD_WENV "../src/quo-vadisd --no-daemonize")
 
+add_library(
+    common-test-utils
+    common-test-utils.h
+    common-test-utils.cc
+)
+
+target_include_directories(
+    common-test-utils
+    PRIVATE
+      $<TARGET_PROPERTY:quo-vadis-core,INCLUDE_DIRECTORIES>
+      $<$<BOOL:${MPI_FOUND}>:${MPI_C_INCLUDE_DIRS}>
+)
+
+target_link_libraries(
+    common-test-utils
+    PRIVATE
+      quo-vadis
+      $<$<BOOL:${MPI_FOUND}>:quo-vadis-mpi>
+)
+
 add_executable(
     test-process-scopes
     test-process-scopes.c
@@ -23,6 +43,7 @@ add_executable(
 
 target_link_libraries(
     test-process-scopes
+    common-test-utils
     quo-vadis
 )
 
@@ -33,6 +54,7 @@ add_executable(
 
 target_link_libraries(
     test-process-hardware
+    common-test-utils
     quo-vadis
 )
 
@@ -109,6 +131,7 @@ if(MPI_FOUND)
 
     target_link_libraries(
         test-mpi-init
+        common-test-utils
         quo-vadis-mpi
     )
 
@@ -119,6 +142,7 @@ if(MPI_FOUND)
 
     target_link_libraries(
         test-mpi-api
+        common-test-utils
         quo-vadis-mpi
     )
 
@@ -129,6 +153,7 @@ if(MPI_FOUND)
 
     target_link_libraries(
         test-mpi-scopes
+        common-test-utils
         quo-vadis-mpi
     )
 
@@ -139,6 +164,7 @@ if(MPI_FOUND)
 
     target_link_libraries(
         test-mpi-scopes-affinity-preserving
+        common-test-utils
         quo-vadis-mpi
     )
 
@@ -149,6 +175,7 @@ if(MPI_FOUND)
 
     target_link_libraries(
         test-mpi-phases
+        common-test-utils
         quo-vadis-mpi
     )
 
@@ -159,6 +186,7 @@ if(MPI_FOUND)
 
     target_link_libraries(
         test-progress-thread
+        common-test-utils
         quo-vadis
         quo-vadis-mpi
     )
@@ -181,6 +209,7 @@ if(MPI_FOUND)
 
     target_link_libraries(
         test-mpi-scope-create
+        common-test-utils
         quo-vadis-mpi
     )
 
@@ -191,6 +220,7 @@ if(MPI_FOUND)
 
     target_link_libraries(
         test-mpi-getdev
+        common-test-utils
         quo-vadis-mpi
     )
 
@@ -201,6 +231,7 @@ if(MPI_FOUND)
 
     target_link_libraries(
         test-mpi-dev-split
+        common-test-utils
         quo-vadis-mpi
     )
 

--- a/tests/common-test-utils.cc
+++ b/tests/common-test-utils.cc
@@ -1,0 +1,329 @@
+/* -*- Mode: C++; c-basic-offset:4; indent-tabs-mode:nil -*- */
+/*
+ * Copyright (c) 2020-2026 Triad National Security, LLC
+ *                         All rights reserved.
+ *
+ * This file is part of the quo-vadis project. See the LICENSE file at the
+ * top-level directory of this distribution.
+ */
+
+/**
+ * @file common-test-utils.cc
+ */
+
+#include "common-test-utils.h"
+
+#include "quo-vadis/config.h"
+#ifdef MPI_FOUND
+#include "quo-vadis-mpi.h"
+#endif
+
+#include <mutex>
+
+// Helps with deterministic task output: a
+// deferred output stream implementation.
+struct dos {
+private:
+    std::mutex m_mutex;
+    char *m_buff = nullptr;
+    dos(void) = default;
+    ~dos(void) {
+        free(m_buff);
+        m_buff = NULL;
+    }
+public:
+    static dos &
+    the_dos(void) {
+        static dos singleton;
+        return singleton;
+    }
+    //Disable copy constructor.
+    dos(const dos &) = delete;
+    // Just return the singleton.
+    dos &
+    operator=(
+        const dos &
+    ) {
+        // Just return the singleton.
+        return dos::the_dos();
+    }
+    //
+    void
+    vadd(
+        const char *format,
+        va_list args
+    ) {
+        std::scoped_lock lock(m_mutex);
+
+        char *inbuff = NULL;
+        int np = vasprintf(&inbuff, format, args);
+        if (np == -1) ctu_panic("OOR");
+
+        char *newbuff = NULL;
+        np = asprintf(&newbuff, "%s%s", m_buff ? m_buff : "", inbuff);
+        if (np == -1) ctu_panic("OOR");
+
+        free(inbuff);
+        free(m_buff);
+
+        m_buff = newbuff;
+    }
+
+    void
+    flush(void)
+    {
+        std::scoped_lock lock(m_mutex);
+
+        printf("%s", m_buff);
+        free(m_buff);
+        m_buff = nullptr;
+    }
+};
+
+void
+ctu_dprintf(
+    const char *format,
+    ...
+) {
+    va_list args;
+    va_start(args, format);
+    dos::the_dos().vadd(format, args);
+    va_end(args);
+}
+
+void
+ctu_dflush(void)
+{
+    dos::the_dos().flush();
+}
+
+#ifdef MPI_FOUND
+
+typedef struct {
+    MPI_Comm comm;
+    int rank;
+    int size;
+    int tok_tag;
+    bool initialized;
+} ctu_mpi_ordered_printer_t;
+
+static inline void
+ctu_mpi_ordered_printer_init(
+    ctu_scope_reporter_t *reporter,
+    qv_scope_t *scope
+) {
+    int rc = MPI_SUCCESS;
+    const char *ers = NULL;
+
+    ctu_mpi_ordered_printer_t *printer = (ctu_mpi_ordered_printer_t *)reporter->printer;
+
+    do {
+        printer->initialized = false;
+        printer->tok_tag = 575;
+
+        rc = qv_mpi_scope_comm_dup(scope, &printer->comm);
+        if (rc != QV_SUCCESS) {
+            ers = "qv_mpi_scope_comm_dup";
+            rc = MPI_ERR_COMM;
+            break;
+        }
+
+        rc = MPI_Comm_rank(printer->comm, &printer->rank);
+        if (rc != MPI_SUCCESS) {
+            ers = "MPI_Comm_rank";
+            break;
+        }
+
+        rc = MPI_Comm_size(printer->comm, &printer->size);
+        if (rc != MPI_SUCCESS) {
+            ers = "MPI_Comm_size";
+            break;
+        }
+
+        printer->initialized = true;
+    } while (0);
+
+    if (rc != MPI_SUCCESS) {
+        ctu_panic("%s failed (rc=%d)", ers, rc);
+    }
+}
+
+static inline int
+ctu_mpi_ordered_printer_id(
+    ctu_scope_reporter_t *reporter
+) {
+    ctu_mpi_ordered_printer_t *printer = (ctu_mpi_ordered_printer_t *)reporter->printer;
+    return printer->rank;
+}
+
+static inline void
+ctu_mpi_ordered_printer_fini(
+    ctu_scope_reporter_t *reporter
+) {
+    int rc = MPI_SUCCESS;
+    const char *ers = NULL;
+
+    ctu_mpi_ordered_printer_t *printer = (ctu_mpi_ordered_printer_t *)reporter->printer;
+
+    if (!printer || !printer->initialized) return;
+    // Ensure all pending operations are complete.
+    do {
+        rc = MPI_Barrier(printer->comm);
+        if (rc != MPI_SUCCESS) {
+            ers = "MPI_Barrier";
+            break;
+        }
+
+        rc = MPI_Comm_free(&printer->comm);
+        if (rc != MPI_SUCCESS) {
+            ers = "MPI_Comm_free";
+            break;
+        }
+        printer->initialized = false;
+        free(printer);
+    } while (0);
+    if (rc != MPI_SUCCESS) {
+        ctu_panic("%s failed (rc=%d)", ers, rc);
+    }
+}
+
+static inline void
+ctu_mpi_wait_token(
+    ctu_scope_reporter_t *reporter
+) {
+    ctu_mpi_ordered_printer_t *printer = (ctu_mpi_ordered_printer_t *)reporter->printer;
+
+    char token = 'a';
+    // Wait for token from previous rank.
+    if (printer->rank > 0) {
+        const int rc = MPI_Recv(
+            &token, 1, MPI_CHAR, printer->rank - 1,
+            printer->tok_tag, printer->comm, MPI_STATUS_IGNORE
+        );
+        if (rc != MPI_SUCCESS) {
+            ctu_panic("%s failed (rc=%d)", "MPI_Recv", rc);
+        }
+    }
+}
+
+static inline void
+ctu_mpi_release_token(
+    ctu_scope_reporter_t *reporter
+) {
+    ctu_mpi_ordered_printer_t *printer = (ctu_mpi_ordered_printer_t *)reporter->printer;
+
+    char token = 'a';
+    // Send token to next rank.
+    if (printer->rank < printer->size - 1) {
+        const int rc = MPI_Send(
+            &token, 1, MPI_CHAR, printer->rank + 1,
+            printer->tok_tag, printer->comm
+        );
+        if (rc != MPI_SUCCESS) {
+            ctu_panic("%s failed (rc=%d)", "MPI_Send", rc);
+        }
+    }
+}
+
+static inline void
+ctu_mpi_ordered_printer_vpprintf(
+    struct ctu_scope_reporter *reporter,
+    bool print,
+    const char *format,
+    va_list args
+) {
+    ctu_mpi_ordered_printer_t *printer = (ctu_mpi_ordered_printer_t *)reporter->printer;
+
+    if (!printer || !printer->initialized || !format) {
+        return;
+    }
+    // Wait for everyone to complete last operation.
+    int rc = MPI_Barrier(printer->comm);
+    if (rc != MPI_SUCCESS) {
+        ctu_panic("%s failed (rc=%d)", "MPI_Barrier", rc);
+    }
+    // Wait for my turn.
+    ctu_mpi_wait_token(reporter);
+    if (print) {
+        // Print formatted message.
+        vprintf(format, args);
+        fflush(stdout);
+    }
+    // Pass it on to the next one.
+    ctu_mpi_release_token(reporter);
+    // Wait for everyone to complete print.
+    rc = MPI_Barrier(printer->comm);
+    if (rc != MPI_SUCCESS) {
+        ctu_panic("%s failed (rc=%d)", "MPI_Barrier", rc);
+    }
+}
+
+static inline void
+ctu_mpi_ordered_printer_printf(
+    ctu_scope_reporter_t *reporter,
+    const char *format,
+    ...
+) {
+    va_list args;
+    va_start(args, format);
+    ctu_mpi_ordered_printer_vpprintf(reporter, true, format, args);
+    va_end(args);
+}
+
+static inline void
+ctu_mpi_ordered_printer_pprintf(
+    struct ctu_scope_reporter *reporter,
+    bool print,
+    const char *format,
+    ...
+) {
+    va_list args;
+    va_start(args, format);
+    ctu_mpi_ordered_printer_vpprintf(reporter, print, format, args);
+    va_end(args);
+}
+
+#endif // #ifdef MPI_FOUND
+
+ctu_scope_reporter_t *
+ctu_reporter_alloc(
+    qv_scope_t *scope,
+    ctu_scope_kind_t kind
+) {
+    ctu_scope_reporter_t *reporter = (ctu_scope_reporter_t *)calloc(1, sizeof(*reporter));
+    if (!reporter) ctu_panic("OOR!");
+
+    switch (kind) {
+        case CTU_SCOPE_KIND_PROCESS:
+        case CTU_SCOPE_KIND_PTHREAD:
+        case CTU_SCOPE_KIND_OPENMP:
+            reporter->printer = NULL;
+            reporter->init = &ctu_default_printer_init;
+            reporter->id = &ctu_default_printer_id;
+            reporter->fini = &ctu_default_printer_fini;
+            reporter->printf = &ctu_default_printer_printf;
+            reporter->pprintf = &ctu_default_printer_pprintf;
+            break;
+        case CTU_SCOPE_KIND_MPI:
+#ifdef QUO_VADIS_MPI
+            reporter->printer = calloc(1, sizeof(ctu_mpi_ordered_printer_t));
+            reporter->init = &ctu_mpi_ordered_printer_init;
+            reporter->id = &ctu_mpi_ordered_printer_id;
+            reporter->fini = &ctu_mpi_ordered_printer_fini;
+            reporter->printf = &ctu_mpi_ordered_printer_printf;
+            reporter->pprintf = &ctu_mpi_ordered_printer_pprintf;
+
+            reporter->init(reporter, scope);
+#else
+            ctu_unused(scope);
+#endif
+            break;
+        default:
+            ctu_panic("Invalid scope kind!");
+    }
+    return reporter;
+}
+
+/*
+ * vim: ft=cpp ts=4 sts=4 sw=4 expandtab
+ */

--- a/tests/common-test-utils.h
+++ b/tests/common-test-utils.h
@@ -1,6 +1,6 @@
 /* -*- Mode: C++; c-basic-offset:4; indent-tabs-mode:nil -*- */
 /*
- * Copyright (c) 2020-2025 Triad National Security, LLC
+ * Copyright (c) 2020-2026 Triad National Security, LLC
  *                         All rights reserved.
  *
  * This file is part of the quo-vadis project. See the LICENSE file at the
@@ -16,6 +16,8 @@
 #ifndef COMMON_TEST_UTILS_H
 #define COMMON_TEST_UTILS_H
 
+// Avoid including internal QV headers here so
+// we mimic real application usage in our tests.
 #include "quo-vadis.h"
 
 #ifndef _GNU_SOURCE
@@ -29,42 +31,6 @@
 #include <string.h>
 #include <sys/syscall.h>
 #include <unistd.h>
-
-#ifdef __cplusplus
-
-static qvi_hwloc_bitmap
-ctu_bitmap_gen_pus(
-    size_t i,
-    size_t n
-) {
-    qvi_hwloc_bitmap result;
-    for (size_t ii = i; ii < n; ++ii) {
-        hwloc_bitmap_set(result.data(), ii);
-    }
-    return result;
-}
-
-static inline std::vector<qvi_hwloc_bitmap>
-ctu_bitmap_split_pus(
-    size_t npus,
-    size_t npieces
-) {
-    std::vector<qvi_hwloc_bitmap> result;
-    const size_t base_chunk_size = npus / npieces;
-    const size_t remainder = npus % npieces;
-    size_t current_pos = 0;
-
-    for (size_t i = 0; i < npieces; ++i) {
-        size_t current_chunk_size = base_chunk_size + (i < remainder ? 1 : 0);
-        result.emplace_back(
-            ctu_bitmap_gen_pus(current_pos, current_pos + current_chunk_size)
-        );
-        current_pos += current_chunk_size;
-    }
-    return result;
-}
-
-#endif
 
 #define CTU_STRINGIFY(x) #x
 #define CTU_TOSTRING(x)  CTU_STRINGIFY(x)
@@ -89,6 +55,10 @@ do {                                                                           \
         ctu_panic(__VA_ARGS__);                                                \
     }                                                                          \
 } while (0)
+
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 typedef enum {
     CTU_SCOPE_KIND_PROCESS = 0,
@@ -139,6 +109,17 @@ static const ctu_devid_name_to_id_t ctu_devid_name_to_id_tab[] = {
     {CTU_TOSTRING(QV_DEVICE_ID_PCI_BUS_ID), QV_DEVICE_ID_PCI_BUS_ID},
     {CTU_TOSTRING(QV_DEVICE_ID_ORDINAL),    QV_DEVICE_ID_ORDINAL}
 };
+
+// A deferred printf implementation.
+void
+ctu_dprintf(
+    const char *format,
+    ...
+);
+
+// Outputs the stored content filled by calls to ctu_dprintf() to stdout.
+void
+ctu_dflush(void);
 
 static inline const char *
 ctu_obj_name(
@@ -409,237 +390,11 @@ ctu_emit_device_info(
     printf("# -----------------------------------------------------------\n");
 }
 
-#if 0
-#define QUO_VADIS_MPI
-#include "mpi.h"
-#endif
-// We assume that the infrastructure-specific headers are included before us.
-#ifdef QUO_VADIS_MPI
-
-typedef struct {
-    MPI_Comm comm;
-    int rank;
-    int size;
-    int tok_tag;
-    bool initialized;
-} ctu_mpi_ordered_printer_t;
-
-static inline void
-ctu_mpi_ordered_printer_init(
-    ctu_scope_reporter_t *reporter,
-    qv_scope_t *scope
-) {
-    int rc = MPI_SUCCESS;
-    char *ers = NULL;
-
-    ctu_mpi_ordered_printer_t *printer = (ctu_mpi_ordered_printer_t *)reporter->printer;
-
-    do {
-        printer->initialized = false;
-        printer->tok_tag = 575;
-
-        rc = qv_mpi_scope_comm_dup(scope, &printer->comm);
-        if (rc != QV_SUCCESS) {
-            ers = "qv_mpi_scope_comm_dup";
-            rc = MPI_ERR_COMM;
-            break;
-        }
-
-        rc = MPI_Comm_rank(printer->comm, &printer->rank);
-        if (rc != MPI_SUCCESS) {
-            ers = "MPI_Comm_rank";
-            break;
-        }
-
-        rc = MPI_Comm_size(printer->comm, &printer->size);
-        if (rc != MPI_SUCCESS) {
-            ers = "MPI_Comm_size";
-            break;
-        }
-
-        printer->initialized = true;
-    } while (0);
-
-    if (rc != MPI_SUCCESS) {
-        ctu_panic("%s failed (rc=%d)", ers, rc);
-    }
-}
-
-static inline int
-ctu_mpi_ordered_printer_id(
-    ctu_scope_reporter_t *reporter
-) {
-    ctu_mpi_ordered_printer_t *printer = (ctu_mpi_ordered_printer_t *)reporter->printer;
-    return printer->rank;
-}
-
-static inline void
-ctu_mpi_ordered_printer_fini(
-    ctu_scope_reporter_t *reporter
-) {
-    int rc = MPI_SUCCESS;
-    char *ers = NULL;
-
-    ctu_mpi_ordered_printer_t *printer = (ctu_mpi_ordered_printer_t *)reporter->printer;
-
-    if (!printer || !printer->initialized) return;
-    // Ensure all pending operations are complete.
-    do {
-        rc = MPI_Barrier(printer->comm);
-        if (rc != MPI_SUCCESS) {
-            ers = "MPI_Barrier";
-            break;
-        }
-
-        rc = MPI_Comm_free(&printer->comm);
-        if (rc != MPI_SUCCESS) {
-            ers = "MPI_Comm_free";
-            break;
-        }
-        printer->initialized = false;
-        free(printer);
-    } while (0);
-    if (rc != MPI_SUCCESS) {
-        ctu_panic("%s failed (rc=%d)", ers, rc);
-    }
-}
-
-static inline void
-ctu_mpi_wait_token(
-    ctu_scope_reporter_t *reporter
-) {
-    ctu_mpi_ordered_printer_t *printer = (ctu_mpi_ordered_printer_t *)reporter->printer;
-
-    char token = 'a';
-    // Wait for token from previous rank.
-    if (printer->rank > 0) {
-        const int rc = MPI_Recv(
-            &token, 1, MPI_CHAR, printer->rank - 1,
-            printer->tok_tag, printer->comm, MPI_STATUS_IGNORE
-        );
-        if (rc != MPI_SUCCESS) {
-            ctu_panic("%s failed (rc=%d)", "MPI_Recv", rc);
-        }
-    }
-}
-
-static inline void
-ctu_mpi_release_token(
-    ctu_scope_reporter_t *reporter
-) {
-    ctu_mpi_ordered_printer_t *printer = (ctu_mpi_ordered_printer_t *)reporter->printer;
-
-    char token = 'a';
-    // Send token to next rank.
-    if (printer->rank < printer->size - 1) {
-        const int rc = MPI_Send(
-            &token, 1, MPI_CHAR, printer->rank + 1,
-            printer->tok_tag, printer->comm
-        );
-        if (rc != MPI_SUCCESS) {
-            ctu_panic("%s failed (rc=%d)", "MPI_Send", rc);
-        }
-    }
-}
-
-static inline void
-ctu_mpi_ordered_printer_vpprintf(
-    struct ctu_scope_reporter *reporter,
-    bool print,
-    const char *format,
-    va_list args
-) {
-    ctu_mpi_ordered_printer_t *printer = (ctu_mpi_ordered_printer_t *)reporter->printer;
-
-    if (!printer || !printer->initialized || !format) {
-        return;
-    }
-    // Wait for everyone to complete last operation.
-    int rc = MPI_Barrier(printer->comm);
-    if (rc != MPI_SUCCESS) {
-        ctu_panic("%s failed (rc=%d)", "MPI_Barrier", rc);
-    }
-    // Wait for my turn.
-    ctu_mpi_wait_token(reporter);
-    if (print) {
-        // Print formatted message.
-        vprintf(format, args);
-        fflush(stdout);
-    }
-    // Pass it on to the next one.
-    ctu_mpi_release_token(reporter);
-    // Wait for everyone to complete print.
-    rc = MPI_Barrier(printer->comm);
-    if (rc != MPI_SUCCESS) {
-        ctu_panic("%s failed (rc=%d)", "MPI_Barrier", rc);
-    }
-}
-
-static inline void
-ctu_mpi_ordered_printer_printf(
-    ctu_scope_reporter_t *reporter,
-    const char *format,
-    ...
-) {
-    va_list args;
-    va_start(args, format);
-    ctu_mpi_ordered_printer_vpprintf(reporter, true, format, args);
-    va_end(args);
-}
-
-static inline void
-ctu_mpi_ordered_printer_pprintf(
-    struct ctu_scope_reporter *reporter,
-    bool print,
-    const char *format,
-    ...
-) {
-    va_list args;
-    va_start(args, format);
-    ctu_mpi_ordered_printer_vpprintf(reporter, print, format, args);
-    va_end(args);
-}
-
-#endif // #ifdef QUO_VADIS_MPI
-
-static inline ctu_scope_reporter_t *
+ctu_scope_reporter_t *
 ctu_reporter_alloc(
     qv_scope_t *scope,
     ctu_scope_kind_t kind
-) {
-    ctu_scope_reporter_t *reporter = (ctu_scope_reporter_t *)calloc(1, sizeof(*reporter));
-    if (!reporter) ctu_panic("OOR!");
-
-    switch (kind) {
-        case CTU_SCOPE_KIND_PROCESS:
-        case CTU_SCOPE_KIND_PTHREAD:
-        case CTU_SCOPE_KIND_OPENMP:
-            reporter->printer = NULL;
-            reporter->init = &ctu_default_printer_init;
-            reporter->id = &ctu_default_printer_id;
-            reporter->fini = &ctu_default_printer_fini;
-            reporter->printf = &ctu_default_printer_printf;
-            reporter->pprintf = &ctu_default_printer_pprintf;
-            break;
-        case CTU_SCOPE_KIND_MPI:
-#ifdef QUO_VADIS_MPI
-            reporter->printer = calloc(1, sizeof(ctu_mpi_ordered_printer_t));
-            reporter->init = &ctu_mpi_ordered_printer_init;
-            reporter->id = &ctu_mpi_ordered_printer_id;
-            reporter->fini = &ctu_mpi_ordered_printer_fini;
-            reporter->printf = &ctu_mpi_ordered_printer_printf;
-            reporter->pprintf = &ctu_mpi_ordered_printer_pprintf;
-
-            reporter->init(reporter, scope);
-#else
-            ctu_unused(scope);
-#endif
-            break;
-        default:
-            ctu_panic("Invalid scope kind!");
-    }
-    return reporter;
-}
+);
 
 static inline void
 ctu_reporter_free(
@@ -874,6 +629,10 @@ ctu_change_bind(
 
     ctu_reporter_free(reporter);
 }
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif
 

--- a/tests/internal/test-map.cc
+++ b/tests/internal/test-map.cc
@@ -9,6 +9,38 @@
 
 #include "common-test-utils.h"
 
+static qvi_hwloc_bitmap
+ctu_bitmap_gen_pus(
+    size_t i,
+    size_t n
+) {
+    qvi_hwloc_bitmap result;
+    for (size_t ii = i; ii < n; ++ii) {
+        hwloc_bitmap_set(result.data(), ii);
+    }
+    return result;
+}
+
+static inline std::vector<qvi_hwloc_bitmap>
+ctu_bitmap_split_pus(
+    size_t npus,
+    size_t npieces
+) {
+    std::vector<qvi_hwloc_bitmap> result;
+    const size_t base_chunk_size = npus / npieces;
+    const size_t remainder = npus % npieces;
+    size_t current_pos = 0;
+
+    for (size_t i = 0; i < npieces; ++i) {
+        size_t current_chunk_size = base_chunk_size + (i < remainder ? 1 : 0);
+        result.emplace_back(
+            ctu_bitmap_gen_pus(current_pos, current_pos + current_chunk_size)
+        );
+        current_pos += current_chunk_size;
+    }
+    return result;
+}
+
 // Empty map test.
 static void
 test_1(void)

--- a/tests/test-mpi-api.c
+++ b/tests/test-mpi-api.c
@@ -143,7 +143,7 @@ main(
     }
 
     if (wrank == 0) {
-        printf("Succcess!\n");
+        printf("Success!\n");
     }
 
     MPI_Finalize();

--- a/tests/test-mpi-dev-split.c
+++ b/tests/test-mpi-dev-split.c
@@ -109,10 +109,12 @@ main(
         ers = "qv_scope_bind_string() failed";
         ctu_panic("%s (rc=%s)", ers, qv_strerr(rc));
     }
-    printf(
+
+    ctu_dprintf(
         "=> [%d] Split@Dev: got %d %s(s), running on %s\n",
         wrank, my_ndevs, dev_name, binds
     );
+
     free(binds);
 
     for (int i = 0; i < my_ndevs; ++i) {
@@ -131,13 +133,15 @@ main(
             ers = "qv_scope_device_id_get() failed";
             ctu_panic("%s (rc=%s)", ers, qv_strerr(rc));
         }
-        printf(
+        ctu_dprintf(
             "   [%d] Dev %d: Ordinal = %s, PCI Bus ID = %s\n",
             wrank, i, ordid, pciid
         );
         free(pciid);
         free(ordid);
     }
+
+    ctu_dflush();
 
     rc = qv_scope_free(dev_scope);
     if (rc != QV_SUCCESS) {


### PR DESCRIPTION
* Move from a header-only implementation to a library for common-test-utils.

* Implement a deferred output stream to improve parallel output determinism. See ctu_dprintf().