### PR TITLE
Start work on completing qv_scope_create().

### DIFF
--- a/include/quo-vadis.h
+++ b/include/quo-vadis.h
@@ -98,12 +98,22 @@ typedef long long qv_scope_flags_t;
 /**
  * Empty flags, get scope with default behavior.
  */
-const qv_scope_flags_t QV_SCOPE_FLAG_NONE   = (0LL);
+const qv_scope_flags_t QV_SCOPE_FLAG_NONE           = (0LL);
 
 /**
  * Disable use of SMT.
  */
-const qv_scope_flags_t QV_SCOPE_FLAG_NO_SMT = (1LL<<0);
+const qv_scope_flags_t QV_SCOPE_FLAG_NO_SMT         = (1LL << 0);
+
+/**
+ * Attempt to create with resources with high affinity to the parent
+ */
+const qv_scope_flags_t QV_SCOPE_FLAG_HINT_CLOSE     = (1LL << 1);
+
+/**
+ *
+ */
+const qv_scope_flags_t QV_SCOPE_FLAG_HINT_EXCLUSIVE = (1LL << 2);
 
 /**
  * Hardware object types.
@@ -168,18 +178,6 @@ const int QV_SCOPE_SPLIT_PACKED = -3;
 const int QV_SCOPE_SPLIT_SPREAD = -4;
 
 /**
- *
- */
-// TODO(skg) Merge with qv_scope_flags_t?
-typedef enum {
-    // TODO(skg) Enumerate all actual values.
-    // TODO(skg) Add to Fortran interface.
-    QV_SCOPE_CREATE_HINT_NONE      = 0,
-    QV_SCOPE_CREATE_HINT_EXCLUSIVE = 1<<0,
-    QV_SCOPE_CREATE_HINT_CLOSE     = 1<<1
-} qv_scope_create_hints_t;
-
-/**
  * Device identifier types.
  */
 typedef enum {
@@ -231,9 +229,9 @@ qv_process_scope_get(
 int
 qv_scope_create(
     qv_scope_t *scope,
+    qv_scope_flags_t flags,
     qv_hw_obj_type_t type,
     int nobjs,
-    qv_scope_create_hints_t hint,
     qv_scope_t **subscope
 );
 

--- a/src/quo-vadis.cc
+++ b/src/quo-vadis.cc
@@ -184,16 +184,16 @@ qv_scope_barrier(
 int
 qv_scope_create(
     qv_scope_t *scope,
+    qv_scope_flags_t flags,
     qv_hw_obj_type_t type,
     int nobjs,
-    qv_scope_create_hints_t hints,
     qv_scope_t **subscope
 ) {
     if (qvi_unlikely(!scope || (nobjs < 0) || !subscope)) {
         return QV_ERR_INVLD_ARG;
     }
     try {
-        return scope->create(type, nobjs, hints, subscope);
+        return scope->create(flags, type, nobjs, subscope);
     }
     qvi_catch_and_return();
 }

--- a/src/qvi-hwpool.cc
+++ b/src/qvi-hwpool.cc
@@ -15,10 +15,10 @@
 
 #include "qvi-hwpool.h"
 
-qv_scope_create_hints_t
-qvi_hwpool_res::hints(void)
+qv_scope_flags_t
+qvi_hwpool_res::flags(void) const
 {
-    return m_hints;
+    return m_flags;
 }
 
 const qvi_hwloc_bitmap &

--- a/src/qvi-hwpool.h
+++ b/src/qvi-hwpool.h
@@ -26,8 +26,8 @@
 struct qvi_hwpool_res {
     friend class cereal::access;
 protected:
-    /** Resource hint flags. */
-    qv_scope_create_hints_t m_hints = QV_SCOPE_CREATE_HINT_NONE;
+    /** Resource flags. */
+    qv_scope_flags_t m_flags = QV_SCOPE_FLAG_NONE;
     /** The resource's affinity encoded as a bitmap. */
     qvi_hwloc_bitmap m_affinity = {};
     /** Polymorphic equality check. */
@@ -42,9 +42,9 @@ public:
     qvi_hwpool_res(
         const qvi_hwloc_bitmap &affinity
     ) : m_affinity(affinity) { }
-    /** Returns the resource's create hints. */
-    qv_scope_create_hints_t
-    hints(void);
+    /** Returns the resource's flags. */
+    qv_scope_flags_t
+    flags(void) const;
     /** Returns a const reference to the resource's affinity bitmap. */
     const qvi_hwloc_bitmap &
     affinity(void) const;
@@ -61,7 +61,7 @@ public:
     serialize(
         Archive &archive
     ) {
-        archive(m_hints, m_affinity);
+        archive(m_flags, m_affinity);
     }
 };
 
@@ -145,7 +145,7 @@ public:
         Archive &archive
     ) {
         archive(
-            m_hints, m_affinity, m_type,
+            m_flags, m_affinity, m_type,
             m_id, m_pci_bus_id, m_uuid
         );
     }

--- a/src/qvi-scope.cc
+++ b/src/qvi-scope.cc
@@ -74,9 +74,9 @@ qv_scope::make_intrinsic(
 // TODO(skg) Implement use of hints.
 int
 qv_scope::create(
+    qv_scope_flags_t,
     qv_hw_obj_type_t type,
     int nobjs,
-    qv_scope_create_hints_t,
     qv_scope_t **child
 ) {
     *child = nullptr;

--- a/src/qvi-scope.h
+++ b/src/qvi-scope.h
@@ -46,14 +46,14 @@ public:
         qv_scope_t **scope
     );
     /**
-     * Creates a new scope based on the specified hardware
-     * type, number of resources, and creation hints.
+     * Creates a new scope based on the specified
+     * flags, hardware type, and number of resources.
      */
     int
     create(
+        qv_scope_flags_t flags,
         qv_hw_obj_type_t type,
         int nobjs,
-        qv_scope_create_hints_t hints,
         qv_scope_t **child
     );
     /** Destroys scopes created by thread_split*. */

--- a/tests/test-mpi-scope-create.c
+++ b/tests/test-mpi-scope-create.c
@@ -73,9 +73,9 @@ test_create_scope(
     qv_scope_t *core_scope;
     int rc = qv_scope_create(
         scope_to_test,
+        QV_SCOPE_FLAG_NONE,
         QV_HW_OBJ_CORE,
         ncores,
-        QV_SCOPE_CREATE_HINT_NONE,
         &core_scope
     );
     if (rc != QV_SUCCESS) {

--- a/tests/test-mpi-scopes.c
+++ b/tests/test-mpi-scopes.c
@@ -148,8 +148,11 @@ main(
     if (base_scope_rank == 0) {
         qv_scope_t *create_scope;
         rc = qv_scope_create(
-            sub_scope, QV_HW_OBJ_CORE,
-            1, 0, &create_scope
+            sub_scope,
+            QV_SCOPE_FLAG_NONE,
+            QV_HW_OBJ_CORE,
+            1,
+            &create_scope
         );
         if (rc != QV_SUCCESS) {
             ers = "qv_scope_create() failed";

--- a/tests/test-progress-thread.c
+++ b/tests/test-progress-thread.c
@@ -140,15 +140,14 @@ int main(int argc, char *argv[])
     }
 
     qv_scope_t *wk_scope;
-    rc = qv_scope_create(task_scope, QV_HW_OBJ_CORE, ncores-1, 0,
-            &wk_scope);
+    rc = qv_scope_create(task_scope, QV_SCOPE_FLAG_NONE, QV_HW_OBJ_CORE, ncores-1, &wk_scope);
     if (rc != QV_SUCCESS) {
         ers = "qv_scope_create() failed";
         ctu_panic("%s (rc=%s)", ers, qv_strerr(rc));
     }
 
     qv_scope_t *ut_scope;
-    rc = qv_scope_create(task_scope, QV_HW_OBJ_CORE, 1, 0, &ut_scope);
+    rc = qv_scope_create(task_scope, QV_SCOPE_FLAG_NONE, QV_HW_OBJ_CORE, 1, &ut_scope);
     if (rc != QV_SUCCESS) {
         ers = "qv_scope_create() failed";
         ctu_panic("%s (rc=%s)", ers, qv_strerr(rc));


### PR DESCRIPTION
We have scope flags, so make consistent use of those for hints, etc. No need for qv_scope_create-specific hints since we have scope flags already.