### PR TITLE
Make qv_thread_scopes_free() behavior match qv_scope_free()'s.

### DIFF
--- a/src/quo-vadis-thread.cc
+++ b/src/quo-vadis-thread.cc
@@ -1,6 +1,6 @@
 /* -*- Mode: C++; c-basic-offset:4; indent-tabs-mode:nil -*- */
 /*qv_policy_t
- * Copyright (c) 2022-2025 Triad National Security, LLC
+ * Copyright (c) 2022-2026 Triad National Security, LLC
  *                         All rights reserved.
  *
  * Copyright (c) 2022-2024 Inria
@@ -141,8 +141,11 @@ qv_thread_scopes_free(
     int nscopes,
     qv_scope_t **scopes
 ) {
-    if (qvi_unlikely(nscopes < 0 || !scopes)) {
+    if (qvi_unlikely(nscopes < 0)) {
         return QV_ERR_INVLD_ARG;
+    }
+    if (!scopes) {
+        return QV_SUCCESS;
     }
     try {
         qv_scope::thread_destroy(&scopes, nscopes);

--- a/src/quo-vadis.cc
+++ b/src/quo-vadis.cc
@@ -111,7 +111,7 @@ qv_scope_free(
     qv_scope_t *scope
 ) {
     // Just accept NULL like free() does.
-    if (qvi_unlikely(!scope)) {
+    if (!scope) {
         return QV_SUCCESS;
     }
     try {


### PR DESCRIPTION
Specifically when passed NULL scopes: just return QV_SUCCESS.