### PR TITLE
Split: restore prior single-process semantics.

### DIFF
--- a/src/qvi-hwsplit.cc
+++ b/src/qvi-hwsplit.cc
@@ -129,8 +129,12 @@ qvi_hwsplit::m_split_cpuset(void)
     const auto [pri_type, pri_cpuset] = m_primary_cpuset_for_split(
         m_split_at_type
     );
-    // The real split size takes the group size into account.
-    const size_t real_split_size = std::min(m_split_size, m_group_size);
+    // If the real split size takes the group size into account, then splits
+    // called by processes will not split at all, since the group size will
+    // always be 1. Restore old process semantics, and don't take the
+    // min(m_split_size, m_group_size).
+    //const size_t real_split_size = std::min(m_split_size, m_group_size);
+    const size_t real_split_size = m_split_size;
     //qvi_log_debug("Real Split Size: {}", real_split_size);
     // Split the primary cpuset into the requested split size pieces.
     return m_my_rmi.hwloc().bitmap_split(

--- a/tests/test-process-scopes.c
+++ b/tests/test-process-scopes.c
@@ -22,8 +22,7 @@ main(void)
         ctu_panic("%s (rc=%s)", ers, qv_strerr(rc));
     }
 
-    ctu_emit_scope_report(self_scope, CTU_SCOPE_KIND_PROCESS, "self_scope");
-    ctu_emit(self_scope, CTU_SCOPE_KIND_PROCESS, "\n");
+    ctu_emit_scope_report(self_scope, CTU_SCOPE_KIND_PROCESS, "     self_scope");
 
     rc = qv_scope_free(self_scope);
     if (rc != QV_SUCCESS) {
@@ -40,19 +39,7 @@ main(void)
         ctu_panic("%s (rc=%s)", ers, qv_strerr(rc));
     }
 
-    ctu_emit_scope_report(base_scope, CTU_SCOPE_KIND_PROCESS, "base_scope");
-    ctu_emit(base_scope, CTU_SCOPE_KIND_PROCESS, "\n");
-
-    int srank;
-    rc = qv_scope_group_rank(base_scope, &srank);
-    if (rc != QV_SUCCESS) {
-        ers = "qv_scope_group_rank() failed";
-        ctu_panic("%s (rc=%s)", ers, qv_strerr(rc));
-    }
-    if (srank != 0) {
-        ers = "Invalid task ID detected";
-        ctu_panic("%s (rc=%s)", ers, qv_strerr(rc));
-    }
+    ctu_emit_scope_report(base_scope, CTU_SCOPE_KIND_PROCESS, "     base_scope");
 
     int sgsize;
     rc = qv_scope_group_size(base_scope, &sgsize);
@@ -66,23 +53,42 @@ main(void)
     }
 
     ctu_emit_host_hw_info(
-        base_scope, CTU_SCOPE_KIND_PROCESS, "base_scope"
+        base_scope, CTU_SCOPE_KIND_PROCESS, "     base_scope"
     );
     ctu_emit(base_scope, CTU_SCOPE_KIND_PROCESS, "\n");
 
     const int npieces = 2;
-    qv_scope_t *sub_scope;
+    qv_scope_t *sub_scope_left;
     rc = qv_scope_split(
-        base_scope, npieces, srank, &sub_scope
+        base_scope, npieces, 0, &sub_scope_left
     );
     if (rc != QV_SUCCESS) {
         ers = "qv_scope_split() failed";
         ctu_panic("%s (rc=%s)", ers, qv_strerr(rc));
     }
 
-    ctu_emit_host_hw_info(sub_scope, CTU_SCOPE_KIND_PROCESS, "sub_scope");
-    ctu_emit(sub_scope, CTU_SCOPE_KIND_PROCESS, "\n");
-    ctu_emit_scope_report(sub_scope, CTU_SCOPE_KIND_PROCESS, "sub_scope");
+    qv_scope_t *sub_scope_right;
+    rc = qv_scope_split(
+        base_scope, npieces, QV_SCOPE_SPLIT_SPREAD, &sub_scope_right
+    );
+    if (rc != QV_SUCCESS) {
+        ers = "qv_scope_split() failed";
+        ctu_panic("%s (rc=%s)", ers, qv_strerr(rc));
+    }
+
+    ctu_emit_host_hw_info(
+        sub_scope_left, CTU_SCOPE_KIND_PROCESS, " sub_scope_left"
+    );
+    ctu_emit_scope_report(
+        sub_scope_left, CTU_SCOPE_KIND_PROCESS, " sub_scope_left"
+    );
+    ctu_emit(sub_scope_left, CTU_SCOPE_KIND_PROCESS, "\n");
+    ctu_emit_host_hw_info(
+        sub_scope_right, CTU_SCOPE_KIND_PROCESS, "sub_scope_right"
+    );
+    ctu_emit_scope_report(
+        sub_scope_right, CTU_SCOPE_KIND_PROCESS, "sub_scope_right"
+    );
 
     rc = qv_scope_free(base_scope);
     if (rc != QV_SUCCESS) {
@@ -90,7 +96,13 @@ main(void)
         ctu_panic("%s (rc=%s)", ers, qv_strerr(rc));
     }
 
-    rc = qv_scope_free(sub_scope);
+    rc = qv_scope_free(sub_scope_left);
+    if (rc != QV_SUCCESS) {
+        ers = "qv_scope_free() failed";
+        ctu_panic("%s (rc=%s)", ers, qv_strerr(rc));
+    }
+
+    rc = qv_scope_free(sub_scope_right);
     if (rc != QV_SUCCESS) {
         ers = "qv_scope_free() failed";
         ctu_panic("%s (rc=%s)", ers, qv_strerr(rc));


### PR DESCRIPTION
If the real split size takes the group size into account, then splits called by processes will not split resources at all, since the group size will always be 1. Restore old process semantics, and don't take min(m_split_size, m_group_size).