### PR TITLE
Fix test-process-scopes.c with cleanups.

### DIFF
--- a/src/qvi-hwsplit.cc
+++ b/src/qvi-hwsplit.cc
@@ -146,7 +146,6 @@ int
 qvi_hwsplit::m_determine_mapping(
     qvi_map_config &map_config
 ) {
-    int rc = QV_SUCCESS;
     // Make sure that the supplied colors are consistent and determine the type
     // of coloring we are using. Positive values denote an explicit coloring
     // provided by the caller. Negative values are reserved for internal use and
@@ -165,13 +164,23 @@ qvi_hwsplit::m_determine_mapping(
     //   - A strict subset is QV_SCOPE_SPLIT_UNDEFINED: user-defined split
     //   - A strict subset is not QV_SCOPE_SPLIT_UNDEFINED: return error code.
     bool auto_split = false;
-    // All colors are positive.
+    // All colors are positive: user-defined split.
     if (tcolors.front() >= 0) {
-        rc = qvi_map_clamp_colors(m_colors);
-        if (qvi_unlikely(rc != QV_SUCCESS)) return rc;
+        // Number of destinations.
+        const size_t m = m_split_cpusets.size();
+        const bool all_in_range = std::ranges::all_of(
+            m_colors, [m](int val) {
+            return val >= 0 && val < static_cast<int>(m);
+        });
+        // Clamp if not all provided values are in a usable
+        // color range. Otherwise, use the values as-is.
+        if (!all_in_range) {
+            const int rc = qvi_map_clamp_colors(m_colors);
+            if (qvi_unlikely(rc != QV_SUCCESS)) return rc;
+        }
     }
-    // Some values are negative.
-    else {
+    // All colors are negative.
+    else if (tcolors.back() < 0) {
         // TODO(skg) Implement the rest.
         if (tcolors.front() != tcolors.back()) {
             return QV_ERR_INVLD_ARG;
@@ -236,16 +245,12 @@ qvi_hwsplit::m_split(void)
     if (qvi_unlikely(thr_map_config.be_verbose)) {
         qvi_map_emit("\nTask ID to Host Hardware Pool", tthr_map);
     }
-#if 0 // NOTE(skg) It seems that we get friendlier semantics excluding this.
-    // Ensure that every task is accounted for in mapping.
-    if (qvi_unlikely(tthr_map.size() != m_group_size)) {
-        qvi_log_error(
-            "Invalid split state: tthr_map.size()={} but m_group_size={}",
-            tthr_map.size(), m_group_size
-        );
-        return QV_ERR_INTERNAL;
-    }
-#endif
+    //
+    // It seems that we get friendlier semantics if we don't require that
+    // every task is accounted for in the mapping. If that changes, then we can
+    // add the check here by verifying that the group size equals the
+    // size of the task-to-hardware-resource map.
+    //
     // Assign cpusets to the tasks' hardware pools based on the determined
     // mapping. Also assign coloring based on this mapping.
     m_colors.resize(tthr_map.size());

--- a/src/qvi-map.cc
+++ b/src/qvi-map.cc
@@ -140,21 +140,18 @@ qvi_map_colors(
     auto &src_colors = config.src_colors;
     const size_t n = src_colors.size();
     const size_t m = config.ndst;
-    // These should be clamped: 0 to m-1, so verify that.
+    // Sanity check: this mapper is valid only with positive color values.
     assert(
-        std::ranges::all_of(src_colors, [m](int val) {
-            return val >= 0 && val < static_cast<int>(m);
+        std::ranges::all_of(config.src_colors, [](int val) {
+            return val >= 0;
         })
     );
-    // Map the color index to its color value,
-    // which corresponds to the destination index.
+    // Assign each source to the piece indicated by its color.
     for (size_t i = 0; i < n; ++i) {
         map[i].insert(src_colors[i]);
     }
     if (qvi_unlikely(config.be_verbose)) {
-        qvi_log_info(
-            "Color Mapping done with N={}, M={}", n, m
-        );
+        qvi_log_info("Color Mapping done with N={}, M={}", n, m);
         qvi_map_emit("Color Mapping", map);
         qvi_log_info(qvi_spadtolen("Color Mapping Done ", "=", vmaxl));
     }
@@ -173,7 +170,7 @@ qvi_map_packed(
     bool inverted = false;
     size_t n = config.nsrc;
     size_t m = config.ndst;
-    // More sources than destinations?
+    // Fewer sources than destinations?
     if (n < m) {
         std::swap(n, m);
         inverted = true;
@@ -224,7 +221,7 @@ qvi_map_spread(
     bool inverted = false;
     size_t n = config.nsrc;
     size_t m = config.ndst;
-    // More sources than destinations?
+    // Fewer sources than destinations?
     if (n < m) {
         std::swap(n, m);
         inverted = true;

--- a/tests/common-test-utils.h
+++ b/tests/common-test-utils.h
@@ -95,6 +95,17 @@ static const ctu_hw_obj_name_to_type_t ctu_hw_obj_name_to_type_tab[] = {
 static const size_t ctu_hw_obj_name_to_type_tab_size =
     sizeof(ctu_hw_obj_name_to_type_tab) / sizeof(ctu_hw_obj_name_to_type_t);
 
+// Maps QV device ID type names to their underlying values.
+static const ctu_devid_name_to_id_t ctu_devid_name_to_id_tab[] = {
+    {CTU_TOSTRING(QV_DEVICE_ID_UUID),       QV_DEVICE_ID_UUID},
+    {CTU_TOSTRING(QV_DEVICE_ID_PCI_BUS_ID), QV_DEVICE_ID_PCI_BUS_ID},
+    {CTU_TOSTRING(QV_DEVICE_ID_ORDINAL),    QV_DEVICE_ID_ORDINAL}
+};
+
+static const size_t ctu_devid_name_to_id_tab_size =
+    sizeof(ctu_devid_name_to_id_tab) / sizeof(ctu_devid_name_to_id_t);
+
+
 static inline const char *
 ctu_obj_name(
     qv_hw_obj_type_t type
@@ -116,16 +127,6 @@ ctu_obj_name(
         default: return "?";
     }
 }
-
-// Maps QV device ID type names to their underlying values.
-static const ctu_devid_name_to_id_t ctu_devid_name_to_id_tab[] = {
-    {CTU_TOSTRING(QV_DEVICE_ID_UUID),       QV_DEVICE_ID_UUID},
-    {CTU_TOSTRING(QV_DEVICE_ID_PCI_BUS_ID), QV_DEVICE_ID_PCI_BUS_ID},
-    {CTU_TOSTRING(QV_DEVICE_ID_ORDINAL),    QV_DEVICE_ID_ORDINAL}
-};
-
-static const size_t ctu_devid_name_to_id_tab_size =
-    sizeof(ctu_devid_name_to_id_tab) / sizeof(ctu_devid_name_to_id_t);
 
 static inline pid_t
 ctu_gettid(void)

--- a/tests/test-process-scopes.c
+++ b/tests/test-process-scopes.c
@@ -1,9 +1,5 @@
 /* -*- Mode: C; c-basic-offset:4; indent-tabs-mode:nil -*- */
 
-/**
- * @file test-process-scopes.c
- */
-
 #include "quo-vadis.h"
 #include "common-test-utils.h"
 
@@ -22,7 +18,9 @@ main(void)
         ctu_panic("%s (rc=%s)", ers, qv_strerr(rc));
     }
 
-    ctu_emit_scope_report(self_scope, CTU_SCOPE_KIND_PROCESS, "     self_scope");
+    ctu_emit_scope_report(
+        self_scope, CTU_SCOPE_KIND_PROCESS, "     self_scope"
+    );
 
     rc = qv_scope_free(self_scope);
     if (rc != QV_SUCCESS) {
@@ -39,7 +37,9 @@ main(void)
         ctu_panic("%s (rc=%s)", ers, qv_strerr(rc));
     }
 
-    ctu_emit_scope_report(base_scope, CTU_SCOPE_KIND_PROCESS, "     base_scope");
+    ctu_emit_scope_report(
+        base_scope, CTU_SCOPE_KIND_PROCESS, "     base_scope"
+    );
 
     int sgsize;
     rc = qv_scope_group_size(base_scope, &sgsize);
@@ -58,6 +58,8 @@ main(void)
     ctu_emit(base_scope, CTU_SCOPE_KIND_PROCESS, "\n");
 
     const int npieces = 2;
+    // Provided color in range, so we will get the LHS of the split.
+    // That is, with 2 pieces, the in-range coloring values are 0 and 1.
     qv_scope_t *sub_scope_left;
     rc = qv_scope_split(
         base_scope, npieces, 0, &sub_scope_left
@@ -66,10 +68,11 @@ main(void)
         ers = "qv_scope_split() failed";
         ctu_panic("%s (rc=%s)", ers, qv_strerr(rc));
     }
-
+    // Provided color in range, so we will get the RHS of the split.
+    // That is, with 2 pieces, the in-range coloring values are 0 and 1.
     qv_scope_t *sub_scope_right;
     rc = qv_scope_split(
-        base_scope, npieces, QV_SCOPE_SPLIT_SPREAD, &sub_scope_right
+        base_scope, npieces, 1, &sub_scope_right
     );
     if (rc != QV_SUCCESS) {
         ers = "qv_scope_split() failed";


### PR DESCRIPTION
Fix single-process split coloring. Now, a single process split can target all pieces of a split by providing a color value that is within the valid coloring range of the particular split. See test-process-scopes.c for more details.