### PR TITLE
Simplify qvi_map_colors().

### DIFF
--- a/src/qvi-hwsplit.cc
+++ b/src/qvi-hwsplit.cc
@@ -191,7 +191,6 @@ qvi_hwsplit::m_determine_mapping(
     if (!auto_split) {
         map_config = {
             m_colors,
-            m_split_cpusets.size(),
             qvi_map_colors
         };
         return QV_SUCCESS;

--- a/src/qvi-map.cc
+++ b/src/qvi-map.cc
@@ -139,7 +139,6 @@ qvi_map_colors(
     }
     auto &src_colors = config.src_colors;
     const size_t n = src_colors.size();
-    const size_t m = config.ndst;
     // Sanity check: this mapper is valid only with positive color values.
     assert(
         std::ranges::all_of(config.src_colors, [](int val) {
@@ -151,7 +150,7 @@ qvi_map_colors(
         map[i].insert(src_colors[i]);
     }
     if (qvi_unlikely(config.be_verbose)) {
-        qvi_log_info("Color Mapping done with N={}, M={}", n, m);
+        qvi_log_info("Color Mapping done with N={}", n);
         qvi_map_emit("Color Mapping", map);
         qvi_log_info(qvi_spadtolen("Color Mapping Done ", "=", vmaxl));
     }

--- a/src/qvi-map.h
+++ b/src/qvi-map.h
@@ -69,10 +69,8 @@ struct qvi_map_config {
 
     qvi_map_config(
         const std::vector<int> &src_colors,
-        const size_t &ndst,
         qvi_map_fn_t map_fn = {}
     ) : be_verbose(qvi_envset(QVI_ENV_VMAP))
-      , ndst(ndst)
       , src_colors(src_colors)
       , map_fn(map_fn) { }
 };

--- a/tests/internal/test-map.cc
+++ b/tests/internal/test-map.cc
@@ -448,11 +448,9 @@ static void
 test_14(void)
 {
     std::vector<int> src_colors = {0, 2, 3, 1};
-    std::vector<qvi_hwloc_bitmap> dst_cpusets = ctu_bitmap_split_pus(4, 4);
 
     qvi_map_config config = {
         src_colors,
-        dst_cpusets.size()
     };
 
     qvi_map_t map;


### PR DESCRIPTION
qvi_map_colors() doesn't require an explicit destination, since a vector of colors provides enough information for the map.