### PR TITLE
Rename _AFFINITY_PRESERVING to _CLOSE.

### DIFF
--- a/include/quo-vadis-thread.h
+++ b/include/quo-vadis-thread.h
@@ -32,9 +32,9 @@ extern "C" {
  * qv_thread_scope_split_at(). The following values can be used instead of
  * group_id to influence how automatic task grouping is accomplished.
  */
-int *const QV_THREAD_SCOPE_SPLIT_PACKED              = (int *)0x00000001;
-int *const QV_THREAD_SCOPE_SPLIT_SPREAD              = (int *)0x00000002;
-int *const QV_THREAD_SCOPE_SPLIT_AFFINITY_PRESERVING = (int *)0x00000003;
+int *const QV_THREAD_SCOPE_SPLIT_PACKED  = (int *)0x00000001;
+int *const QV_THREAD_SCOPE_SPLIT_SPREAD  = (int *)0x00000002;
+int *const QV_THREAD_SCOPE_SPLIT_CLOSE   = (int *)0x00000003;
 
 int
 qv_thread_scope_split(

--- a/include/quo-vadis.h
+++ b/include/quo-vadis.h
@@ -167,7 +167,7 @@ const int QV_SCOPE_SPLIT_UNDEFINED = -1;
  * Split the provided group by attempting to preserve tasks' current affinities
  * (at time of the split call) as much as possible.
  */
-const int QV_SCOPE_SPLIT_AFFINITY_PRESERVING = -2;
+const int QV_SCOPE_SPLIT_CLOSE = -2;
 /**
  *
  */

--- a/src/fortran/quo-vadisf.f90
+++ b/src/fortran/quo-vadisf.f90
@@ -78,7 +78,7 @@ module quo_vadisf
     ! Automatic grouping options for qv_scope_split().
     !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
     integer(c_int), parameter :: QV_SCOPE_SPLIT_UNDEFINED = -1
-    integer(c_int), parameter :: QV_SCOPE_SPLIT_AFFINITY_PRESERVING = -2
+    integer(c_int), parameter :: QV_SCOPE_SPLIT_CLOSE = -2
 
     !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
     ! Device ID types

--- a/src/quo-vadis-thread.cc
+++ b/src/quo-vadis-thread.cc
@@ -84,8 +84,8 @@ split_color_fixup(
     else if (kcolors == QV_THREAD_SCOPE_SPLIT_SPREAD) {
         real_color = QV_SCOPE_SPLIT_SPREAD;
     }
-    else if (kcolors == QV_THREAD_SCOPE_SPLIT_AFFINITY_PRESERVING) {
-        real_color = QV_SCOPE_SPLIT_AFFINITY_PRESERVING;
+    else if (kcolors == QV_THREAD_SCOPE_SPLIT_CLOSE) {
+        real_color = QV_SCOPE_SPLIT_CLOSE;
     }
     // Nothing to do. An automatic coloring was not requested.
     if (real_color == QV_SCOPE_SPLIT_UNDEFINED) {

--- a/src/qvi-hwsplit.cc
+++ b/src/qvi-hwsplit.cc
@@ -201,11 +201,11 @@ qvi_hwsplit::m_determine_mapping(
     }
     // Automatic splitting.
     switch (m_colors[0]) {
-        case QV_SCOPE_SPLIT_AFFINITY_PRESERVING: {
+        case QV_SCOPE_SPLIT_CLOSE: {
             map_config = {
                 m_task_affinities,
                 m_split_cpusets,
-                qvi_map_affinity_preserving
+                qvi_map_close
             };
             return QV_SUCCESS;
         }
@@ -284,7 +284,7 @@ qvi_hwsplit::m_split(void)
             hwpool_affinities
         };
         qvi_map_t devs2hres_map;
-        rc = qvi_map_affinity_preserving(
+        rc = qvi_map_close(
             devs2hres_config, devs2hres_map
         );
         if (qvi_unlikely(rc != QV_SUCCESS)) return rc;

--- a/src/qvi-map.cc
+++ b/src/qvi-map.cc
@@ -664,7 +664,7 @@ solve_ap_mapping(
 }
 
 int
-qvi_map_affinity_preserving(
+qvi_map_close(
     const qvi_map_config &config,
     qvi_map_t &map
 ) {

--- a/src/qvi-map.h
+++ b/src/qvi-map.h
@@ -123,10 +123,10 @@ qvi_map_spread(
 );
 
 /**
- * Performs an affinity preserving mapping.
+ * Performs a close (affinity preserving) mapping.
  */
 int
-qvi_map_affinity_preserving(
+qvi_map_close(
     const qvi_map_config &config,
     qvi_map_t &map
 );

--- a/tests/internal/test-map.cc
+++ b/tests/internal/test-map.cc
@@ -54,7 +54,7 @@ test_1(void)
     };
 
     qvi_map_t map;
-    int rc = qvi_map_affinity_preserving(
+    int rc = qvi_map_close(
         config, map
     );
     ctu_assert(rc == QV_SUCCESS, "%d != QV_SUCCESS", rc);
@@ -76,7 +76,7 @@ test_2(void)
     };
 
     qvi_map_t map;
-    int rc = qvi_map_affinity_preserving(
+    int rc = qvi_map_close(
         config, map
     );
     ctu_assert(rc == QV_SUCCESS, "%d != QV_SUCCESS", rc);
@@ -104,7 +104,7 @@ test_3(void)
     };
 
     qvi_map_t map;
-    int rc = qvi_map_affinity_preserving(
+    int rc = qvi_map_close(
         config, map
     );
     ctu_assert(rc == QV_SUCCESS, "%d != QV_SUCCESS", rc);
@@ -135,7 +135,7 @@ test_4(void)
     };
 
     qvi_map_t map;
-    int rc = qvi_map_affinity_preserving(
+    int rc = qvi_map_close(
         config, map
     );
     ctu_assert(rc == QV_SUCCESS, "%d != QV_SUCCESS", rc);
@@ -164,7 +164,7 @@ test_5(void)
     };
 
     qvi_map_t map;
-    int rc = qvi_map_affinity_preserving(
+    int rc = qvi_map_close(
         config, map
     );
     ctu_assert(rc == QV_SUCCESS, "%d != QV_SUCCESS", rc);
@@ -194,7 +194,7 @@ test_6(void)
     };
 
     qvi_map_t map;
-    int rc = qvi_map_affinity_preserving(
+    int rc = qvi_map_close(
         config, map
     );
     ctu_assert(rc == QV_SUCCESS, "%d != QV_SUCCESS", rc);
@@ -226,7 +226,7 @@ test_7(void)
     };
 
     qvi_map_t map;
-    int rc = qvi_map_affinity_preserving(
+    int rc = qvi_map_close(
         config, map
     );
     ctu_assert(rc == QV_SUCCESS, "%d != QV_SUCCESS", rc);
@@ -261,7 +261,7 @@ test_8(void)
     };
 
     qvi_map_t map;
-    int rc = qvi_map_affinity_preserving(
+    int rc = qvi_map_close(
         config, map
     );
     ctu_assert(rc == QV_SUCCESS, "%d != QV_SUCCESS", rc);
@@ -297,7 +297,7 @@ test_9(void)
     };
 
     qvi_map_t map;
-    int rc = qvi_map_affinity_preserving(
+    int rc = qvi_map_close(
         config, map
     );
     ctu_assert(rc == QV_SUCCESS, "%d != QV_SUCCESS", rc);

--- a/tests/test-mpi-phases.c
+++ b/tests/test-mpi-phases.c
@@ -108,8 +108,8 @@ main(
     rc = qv_scope_split(
         base_scope,
         wsize,        // Number of workers
-#ifdef USE_AFFINITY_PRESERVING
-    QV_SCOPE_SPLIT_AFFINITY_PRESERVING,
+#ifdef USE_CLOSE
+    QV_SCOPE_SPLIT_CLOSE,
 #else
     wrank,        // My group color
 #endif
@@ -234,8 +234,8 @@ main(
     rc = qv_scope_split_at(
         base_scope,
         QV_HW_OBJ_NUMANODE,
-#ifdef USE_AFFINITY_PRESERVING
-        QV_SCOPE_SPLIT_AFFINITY_PRESERVING,
+#ifdef USE_CLOSE
+        QV_SCOPE_SPLIT_CLOSE,
 #else
         wrank % nnumas, // color or group id
 #endif

--- a/tests/test-omp.c
+++ b/tests/test-omp.c
@@ -49,7 +49,7 @@ scopei_ep(
         ctu_panic("%s (rc=%s)", ers, qv_strerr(rc));
     }
 
-    int *thread_coloring = QV_THREAD_SCOPE_SPLIT_AFFINITY_PRESERVING;
+    int *thread_coloring = QV_THREAD_SCOPE_SPLIT_CLOSE;
     rc = qv_thread_scope_split_at(
         base_scope, QV_HW_OBJ_CORE, thread_coloring,
         sinfo->nthreads, &sinfo->th_scopes


### PR DESCRIPTION
Rename various forms of 'affinity preserving' to 'close.'

Fixes #540.