### PR TITLE
Simplify user-facing API.

### DIFF
--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -38,20 +38,20 @@ sub-scope maximizes locality for a given worker.
 
 ```C
 // Predefined
-qv_process_scope_get(QV_SCOPE_USER, QV_SCOPE_FLAG_NONE, &uscope);
+qv_process_scope(QV_SCOPE_USER, QV_SCOPE_FLAG_NONE, &uscope);
 
 // Derived
-// See qv_scope_split() and qv_scope_split_at()
+// See qv_split() and qv_split_at()
 ```
 
 ### Hardware and Software Queries
 
 ```C
 // Hardware topology queries
-rc = qv_scope_hw_obj_count(uscope, QV_HW_OBJ_GPU, &ngpus);
+rc = qv_hw_obj_count(uscope, QV_HW_OBJ_GPU, &ngpus);
 
 // Caller-state queries
-qv_scope_bind_string(uscope, QV_BIND_STRING_LOGICAL, &bindstr);
+qv_bind_string(uscope, QV_BIND_STRING_LOGICAL, &bindstr);
 ```
 
 ### Split Operations: Distribute Resources to Workers
@@ -60,13 +60,13 @@ qv_scope_bind_string(uscope, QV_BIND_STRING_LOGICAL, &bindstr);
 // Splits are collective operations: Every caller gets its own subscope
 
 // For example: comm_size as num_workers, comm_rank as color
-qv_scope_split(ctx, base_scope, size, rank, &sub_scope);
+qv_split(ctx, base_scope, size, rank, &sub_scope);
 
 // Or split by a specific resource type
-qv_scope_split_at(ctx, base_scope, QV_HW_OBJ_NUMANODE, rank%nnumas, &numa_scope);
+qv_split_at(ctx, base_scope, QV_HW_OBJ_NUMANODE, rank%nnumas, &numa_scope);
 
 // including accelerators
-qv_scope_split_at(ctx, base_scope, QV_HW_OBJ_GPU, rank%ngpus, &gpu_scope);
+qv_split_at(ctx, base_scope, QV_HW_OBJ_GPU, rank%ngpus, &gpu_scope);
 ```
 
 ### Stack-Based Semantics to Map Workers to Hardware
@@ -92,7 +92,7 @@ if (my_numa_id == 0) {
 }
 
 // Everybody else waits
-qv_scope_barrier(ctx, numa_scope);
+qv_barrier(ctx, numa_scope);
 ```
 
 ### Accelerator support
@@ -161,67 +161,67 @@ main(
     ////////////////////////////////////////////////////////////////////////////
     // Get the base scope: RM-given resources.
     qv_scope_t *base_scope;
-    rc = qv_mpi_scope_get(
+    rc = qv_mpi_scope(
         comm, QV_SCOPE_USER, QV_SCOPE_FLAG_NONE, &base_scope
     );
     if (rc != QV_SUCCESS) {
-        ers = "qv_mpi_scope_get() failed";
+        ers = "qv_mpi_scope() failed";
         ctu_panic("%s (rc=%s)", ers, qv_strerr(rc));
     }
 
     int nnumas;
-    rc = qv_scope_hw_obj_count(base_scope, QV_HW_OBJ_NUMANODE, &nnumas);
+    rc = qv_hw_obj_count(base_scope, QV_HW_OBJ_NUMANODE, &nnumas);
     if (rc != QV_SUCCESS) {
-        ers = "qv_scope_hw_obj_count() failed";
+        ers = "qv_hw_obj_count() failed";
         ctu_panic("%s (rc=%s)", ers, qv_strerr(rc));
     }
     // Split at NUMA domains.
     qv_scope_t *numa_scope;
-    rc = qv_scope_split_at(
+    rc = qv_split_at(
         base_scope, QV_HW_OBJ_NUMANODE,
         wrank % nnumas, &numa_scope
     );
     if (rc != QV_SUCCESS) {
-        ers = "qv_scope_split_at() failed";
+        ers = "qv_split_at() failed";
         ctu_panic("%s (rc=%s)", ers, qv_strerr(rc));
     }
     // When there's more tasks than NUMAs,
     // make sure each task has exclusive resources.
     int lrank;
-    rc = qv_scope_group_rank(numa_scope, &lrank);
+    rc = qv_group_rank(numa_scope, &lrank);
     if (rc != QV_SUCCESS) {
-        ers = "qv_scope_group_rank() failed";
+        ers = "qv_group_rank() failed";
         ctu_panic("%s (rc=%s)", ers, qv_strerr(rc));
     }
 
     int ntasks_per_numa;
-    rc = qv_scope_group_size(numa_scope, &ntasks_per_numa);
+    rc = qv_group_size(numa_scope, &ntasks_per_numa);
     if (rc != QV_SUCCESS) {
-        ers = "qv_scope_group_size() failed";
+        ers = "qv_group_size() failed";
         ctu_panic("%s (rc=%s)", ers, qv_strerr(rc));
     }
 
     qv_scope_t *subnuma;
-    rc = qv_scope_split(
+    rc = qv_split(
         numa_scope, ntasks_per_numa,
         lrank % ntasks_per_numa, &subnuma
     );
     if (rc != QV_SUCCESS) {
-        ers = "qv_scope_split() failed";
+        ers = "qv_split() failed";
         ctu_panic("%s (rc=%s)", ers, qv_strerr(rc));
     }
     // Get the number of cores and pus per NUMA part.
     int ncores;
-    rc = qv_scope_hw_obj_count(subnuma, QV_HW_OBJ_CORE, &ncores);
+    rc = qv_hw_obj_count(subnuma, QV_HW_OBJ_CORE, &ncores);
     if (rc != QV_SUCCESS) {
-        ers = "qv_scope_hw_obj_count() failed";
+        ers = "qv_hw_obj_count() failed";
         ctu_panic("%s (rc=%s)", ers, qv_strerr(rc));
     }
 
     int npus;
-    rc = qv_scope_hw_obj_count(subnuma, QV_HW_OBJ_PU, &npus);
+    rc = qv_hw_obj_count(subnuma, QV_HW_OBJ_PU, &npus);
     if (rc != QV_SUCCESS) {
-        ers = "qv_scope_hw_obj_count() failed";
+        ers = "qv_hw_obj_count() failed";
         ctu_panic("%s (rc=%s)", ers, qv_strerr(rc));
     }
     ////////////////////////////////////////////////////////////////////////////
@@ -230,11 +230,11 @@ main(
     const int nthreads = ncores;
     int *thread_coloring = NULL; // Default thread assignment.
     qv_scope_t **th_scopes;
-    rc = qv_thread_scope_split_at(
+    rc = qv_thread_split_at(
         subnuma, QV_HW_OBJ_CORE, thread_coloring, nthreads, &th_scopes
     );
     if (rc != QV_SUCCESS) {
-        ers = "qv_thread_scope_split_at() failed";
+        ers = "qv_thread_split_at() failed";
         ctu_panic("%s (rc=%s)", ers, qv_strerr(rc));
     }
 
@@ -243,13 +243,13 @@ main(
     {
         const int tid = omp_get_thread_num();
         // Each thread works with its new hardware affinity.
-        qv_scope_bind_push(th_scopes[tid]);
+        qv_bind_push(th_scopes[tid]);
         thread_work(th_scopes[tid]);
     }
     // When we are done with the scope, clean up.
-    rc = qv_thread_scopes_free(nthreads, th_scopes);
+    rc = qv_thread_free(nthreads, th_scopes);
     if (rc != QV_SUCCESS) {
-        ers = "qv_thread_scopes_free() failed";
+        ers = "qv_thread_free() failed";
         ctu_panic("%s (rc=%s)", ers, qv_strerr(rc));
     }
     ////////////////////////////////////////////////////////////////////////////
@@ -259,11 +259,11 @@ main(
     // *   Note num_threads < num_places on SMT
     ////////////////////////////////////////////////////////////////////////////
     thread_coloring = QV_THREAD_SCOPE_SPLIT_PACKED,
-    rc = qv_thread_scope_split_at(
+    rc = qv_thread_split_at(
         subnuma, QV_HW_OBJ_PU, thread_coloring, nthreads, &th_scopes
     );
     if (rc != QV_SUCCESS) {
-        ers = "qv_thread_scope_split_at() failed";
+        ers = "qv_thread_split_at() failed";
         ctu_panic("%s (rc=%s)", ers, qv_strerr(rc));
     }
 
@@ -288,15 +288,15 @@ main(
     }
     free(pthrds);
     // When we are done with the scope, clean up.
-    rc = qv_thread_scopes_free(nthreads, th_scopes);
+    rc = qv_thread_free(nthreads, th_scopes);
     if (rc != QV_SUCCESS) {
-        ers = "qv_thread_scopes_free() failed";
+        ers = "qv_thread_free() failed";
         ctu_panic("%s (rc=%s)", ers, qv_strerr(rc));
     }
     // Clean up.
-    qv_scope_free(subnuma);
-    qv_scope_free(numa_scope);
-    qv_scope_free(base_scope);
+    qv_free(subnuma);
+    qv_free(numa_scope);
+    qv_free(base_scope);
 
     MPI_Finalize();
 

--- a/include/quo-vadis-mpi.h
+++ b/include/quo-vadis-mpi.h
@@ -1,6 +1,6 @@
 /* -*- Mode: C; c-basic-offset:4; indent-tabs-mode:nil -*- */
 /*
- * Copyright (c) 2020-2025 Triad National Security, LLC
+ * Copyright (c) 2020-2026 Triad National Security, LLC
  *                         All rights reserved.
  *
  * Copyright (c) 2020-2021 Lawrence Livermore National Security, LLC
@@ -33,7 +33,7 @@ extern "C" {
  * communicator.
  */
 int
-qv_mpi_scope_get(
+qv_mpi_scope(
     MPI_Comm comm,
     qv_scope_intrinsic_t iscope,
     qv_scope_flags_t flags,
@@ -45,7 +45,7 @@ qv_mpi_scope_get(
  * provided scope. The returned communicator must be freed by MPI_Comm_free().
  */
 int
-qv_mpi_scope_comm_dup(
+qv_mpi_comm_dup(
     qv_scope_t *scope,
     MPI_Comm *comm
 );

--- a/include/quo-vadis-thread.h
+++ b/include/quo-vadis-thread.h
@@ -28,8 +28,8 @@ extern "C" {
 #endif
 
 /**
- * Automatic grouping options for qv_thread_scope_split() and
- * qv_thread_scope_split_at(). The following values can be used instead of
+ * Automatic grouping options for qv_thread_split() and
+ * qv_thread_split_at(). The following values can be used instead of
  * group_id to influence how automatic task grouping is accomplished.
  */
 int *const QV_THREAD_SCOPE_SPLIT_PACKED  = (int *)0x00000001;
@@ -37,7 +37,7 @@ int *const QV_THREAD_SCOPE_SPLIT_SPREAD  = (int *)0x00000002;
 int *const QV_THREAD_SCOPE_SPLIT_CLOSE   = (int *)0x00000003;
 
 int
-qv_thread_scope_split(
+qv_thread_split(
     qv_scope_t *scope,
     int npieces,
     int *kcolors,
@@ -46,7 +46,7 @@ qv_thread_scope_split(
 );
 
 int
-qv_thread_scope_split_at(
+qv_thread_split_at(
     qv_scope_t *scope,
     qv_hw_obj_type_t type,
     int *kcolors,
@@ -55,11 +55,11 @@ qv_thread_scope_split_at(
 );
 
 /**
- * Frees resources allocated by calls to qv_thread_scope_split*.
+ * Frees resources allocated by calls to qv_thread_split*.
  */
 // TODO(skg) flip ordering.
 int
-qv_thread_scopes_free(
+qv_thread_free(
     int nscopes,
     qv_scope_t **scopes
 );

--- a/include/quo-vadis.h
+++ b/include/quo-vadis.h
@@ -152,7 +152,7 @@ const qv_bind_string_flags_t QV_BIND_STRING_LOGICAL = (1<<0);
 const qv_bind_string_flags_t QV_BIND_STRING_PHYSICAL = (1<<1);
 
 /**
- * Automatic grouping options for qv_scope_split() and qv_scope_split_at(). The
+ * Automatic grouping options for qv_split() and qv_split_at(). The
  * following values can be used instead of group_id to influence how automatic
  * task grouping is accomplished.
  */
@@ -216,7 +216,7 @@ qv_strerr(
  * Creates a process context.
  */
 int
-qv_process_scope_get(
+qv_process_scope(
     qv_scope_intrinsic_t iscope,
     qv_scope_flags_t flags,
     qv_scope_t **scope
@@ -227,7 +227,7 @@ qv_process_scope_get(
  */
 // TODO(skg) Add to Fortran interface.
 int
-qv_scope_create(
+qv_create_scope(
     qv_scope_t *scope,
     qv_scope_flags_t flags,
     qv_hw_obj_type_t type,
@@ -239,7 +239,7 @@ qv_scope_create(
  * Returns the caller's group rank in the provided scope.
  */
 int
-qv_scope_group_rank(
+qv_group_rank(
     qv_scope_t *scope,
     int *rank
 );
@@ -248,7 +248,7 @@ qv_scope_group_rank(
  * Returns the scope's underlying group's size.
  */
 int
-qv_scope_group_size(
+qv_group_size(
     qv_scope_t *scope,
     int *group_size
 );
@@ -257,7 +257,7 @@ qv_scope_group_size(
  * Returns the number of hardware objects contained within the provided scope.
  */
 int
-qv_scope_hw_obj_count(
+qv_hw_obj_count(
     qv_scope_t *scope,
     qv_hw_obj_type_t obj,
     int *nobjs
@@ -267,7 +267,7 @@ qv_scope_hw_obj_count(
  *
  */
 int
-qv_scope_device_id(
+qv_device_id(
     qv_scope_t *scope,
     qv_hw_obj_type_t dev_obj,
     int dev_index,
@@ -279,7 +279,7 @@ qv_scope_device_id(
  *
  */
 int
-qv_scope_barrier(
+qv_barrier(
     qv_scope_t *scope
 );
 
@@ -287,7 +287,7 @@ qv_scope_barrier(
  *
  */
 int
-qv_scope_split(
+qv_split(
     qv_scope_t *scope,
     int npieces,
     int group_id,
@@ -298,7 +298,7 @@ qv_scope_split(
  *
  */
 int
-qv_scope_split_at(
+qv_split_at(
     qv_scope_t *scope,
     qv_hw_obj_type_t type,
     int group_id,
@@ -309,7 +309,7 @@ qv_scope_split_at(
  *
  */
 int
-qv_scope_bind_push(
+qv_bind_push(
     qv_scope_t *scope
 );
 
@@ -317,7 +317,7 @@ qv_scope_bind_push(
  *
  */
 int
-qv_scope_bind_pop(
+qv_bind_pop(
     qv_scope_t *scope
 );
 
@@ -325,7 +325,7 @@ qv_scope_bind_pop(
  *
  */
 int
-qv_scope_bind_string(
+qv_bind_string(
     qv_scope_t *scope,
     qv_bind_string_flags_t flags,
     char **str
@@ -335,7 +335,7 @@ qv_scope_bind_string(
  * Releases resources associated with the provided scope.
  */
 int
-qv_scope_free(
+qv_free(
     qv_scope_t *scope
 );
 

--- a/src/fortran/quo-vadis-mpif.f90
+++ b/src/fortran/quo-vadis-mpif.f90
@@ -12,7 +12,7 @@ module quo_vadis_mpif
 
 interface
     integer(c_int) &
-    function qv_mpi_scope_get_c(comm, iscope, flags, scope) &
+    function qv_mpi_scope_c(comm, iscope, flags, scope) &
         bind(c, name='qvi_mpi_scope_get_f2c')
         use, intrinsic :: iso_c_binding, only: c_ptr, c_long_long, c_int
         implicit none
@@ -20,22 +20,22 @@ interface
         integer(c_int), value :: iscope
         integer(c_long_long), value :: flags
         type(c_ptr), intent(out) :: scope
-    end function qv_mpi_scope_get_c
+    end function qv_mpi_scope_c
 
     integer(c_int) &
-    function qv_mpi_scope_comm_dup_c(scope, comm) &
+    function qv_mpi_comm_dup_c(scope, comm) &
         bind(c, name='qvi_mpi_scope_comm_dup_f2c')
         use, intrinsic :: iso_c_binding, only: c_ptr, c_int
         implicit none
         type(c_ptr), value :: scope
         integer(c_int), intent(out) :: comm
-    end function qv_mpi_scope_comm_dup_c
+    end function qv_mpi_comm_dup_c
 
 end interface
 
 contains
 
-    subroutine qv_mpi_scope_get(comm, iscope, flags, scope, info)
+    subroutine qv_mpi_scope(comm, iscope, flags, scope, info)
         use, intrinsic :: iso_c_binding, only: c_ptr, c_int, c_long_long
         implicit none
         integer, value :: comm
@@ -43,17 +43,17 @@ contains
         integer(c_long_long), value :: flags
         type(c_ptr), intent(out) :: scope
         integer(c_int), intent(out) :: info
-        info = qv_mpi_scope_get_c(comm, iscope, flags, scope)
-    end subroutine qv_mpi_scope_get
+        info = qv_mpi_scope_c(comm, iscope, flags, scope)
+    end subroutine qv_mpi_scope
 
-    subroutine qv_mpi_scope_comm_dup(scope, comm, info)
+    subroutine qv_mpi_comm_dup(scope, comm, info)
         use, intrinsic :: iso_c_binding, only: c_ptr, c_int
         implicit none
         type(c_ptr), value :: scope
         integer, intent(out) :: comm
         integer(c_int), intent(out) :: info
-        info =  qv_mpi_scope_comm_dup_c(scope, comm)
-    end subroutine qv_mpi_scope_comm_dup
+        info =  qv_mpi_comm_dup_c(scope, comm)
+    end subroutine qv_mpi_comm_dup
 
 end module quo_vadis_mpif
 

--- a/src/fortran/quo-vadisf.f90
+++ b/src/fortran/quo-vadisf.f90
@@ -75,7 +75,7 @@ module quo_vadisf
         int(ishft(1, 1), kind=c_int)
 
     !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-    ! Automatic grouping options for qv_scope_split().
+    ! Automatic grouping options for qv_split().
     !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
     integer(c_int), parameter :: QV_SCOPE_SPLIT_UNDEFINED = -1
     integer(c_int), parameter :: QV_SCOPE_SPLIT_CLOSE = -2
@@ -107,90 +107,90 @@ interface
     end function qv_version_c
 
     integer(c_int) &
-    function qv_process_scope_get_c(iscope, flags, scope) &
-        bind(c, name='qv_process_scope_get')
+    function qv_process_scope_c(iscope, flags, scope) &
+        bind(c, name='qv_process_scope')
         use, intrinsic :: iso_c_binding, only: c_int, c_long_long, c_ptr
         implicit none
         integer(c_int), value :: iscope
         integer(c_long_long), value :: flags
         type(c_ptr), intent(out) :: scope
-    end function qv_process_scope_get_c
+    end function qv_process_scope_c
 
     integer(c_int) &
-    function qv_scope_free_c(scope) &
-        bind(c, name='qv_scope_free')
+    function qv_free_c(scope) &
+        bind(c, name='qv_free')
         use, intrinsic :: iso_c_binding, only: c_ptr, c_int
         implicit none
         type(c_ptr), value :: scope
-    end function qv_scope_free_c
+    end function qv_free_c
 
     integer(c_int) &
-    function qv_scope_split_c( &
+    function qv_split_c( &
         scope, npieces, group_id, subscope &
     ) &
-        bind(c, name='qv_scope_split')
+        bind(c, name='qv_split')
         use, intrinsic :: iso_c_binding, only: c_ptr, c_int
         implicit none
         type(c_ptr), value :: scope
         integer(c_int), value :: npieces
         integer(c_int), value :: group_id
         type(c_ptr), intent(out) :: subscope
-    end function qv_scope_split_c
+    end function qv_split_c
 
     integer(c_int) &
-    function qv_scope_split_at_c( &
+    function qv_split_at_c( &
         scope, obj_type, group_id, subscope &
     ) &
-        bind(c, name='qv_scope_split_at')
+        bind(c, name='qv_split_at')
         use, intrinsic :: iso_c_binding, only: c_ptr, c_int
         implicit none
         type(c_ptr), value :: scope
         integer(c_int), value :: obj_type
         integer(c_int), value :: group_id
         type(c_ptr), intent(out) :: subscope
-    end function qv_scope_split_at_c
+    end function qv_split_at_c
 
     integer(c_int) &
-    function qv_scope_hw_obj_count_c(scope, obj, n) &
-        bind(c, name='qv_scope_hw_obj_count')
+    function qv_hw_obj_count_c(scope, obj, n) &
+        bind(c, name='qv_hw_obj_count')
         use, intrinsic :: iso_c_binding, only: c_ptr, c_int
         implicit none
         type(c_ptr), value :: scope
         integer(c_int), value :: obj
         integer(c_int), intent(out) :: n
-    end function qv_scope_hw_obj_count_c
+    end function qv_hw_obj_count_c
 
     integer(c_int) &
-    function qv_scope_group_rank_c(scope, taskid) &
-        bind(c, name='qv_scope_group_rank')
+    function qv_group_rank_c(scope, taskid) &
+        bind(c, name='qv_group_rank')
         use, intrinsic :: iso_c_binding, only: c_ptr, c_int
         implicit none
         type(c_ptr), value :: scope
         integer(c_int), intent(out) :: taskid
-    end function qv_scope_group_rank_c
+    end function qv_group_rank_c
 
     integer(c_int) &
-    function qv_scope_group_size_c(scope, ntasks) &
-        bind(c, name='qv_scope_group_size')
+    function qv_group_size_c(scope, ntasks) &
+        bind(c, name='qv_group_size')
         use, intrinsic :: iso_c_binding, only: c_ptr, c_int
         implicit none
         type(c_ptr), value :: scope
         integer(c_int), intent(out) :: ntasks
-    end function qv_scope_group_size_c
+    end function qv_group_size_c
 
     integer(c_int) &
-    function qv_scope_barrier_c(scope) &
-        bind(c, name='qv_scope_barrier')
+    function qv_barrier_c(scope) &
+        bind(c, name='qv_barrier')
         use, intrinsic :: iso_c_binding, only: c_ptr, c_int
         implicit none
         type(c_ptr), value :: scope
-    end function qv_scope_barrier_c
+    end function qv_barrier_c
 
     integer(c_int) &
-    function qv_scope_device_id_c( &
+    function qv_device_id_c( &
         scope, dev_obj, i, id_type, dev_id &
     ) &
-        bind(c, name='qv_scope_device_id')
+        bind(c, name='qv_device_id')
         use, intrinsic :: iso_c_binding, only: c_ptr, c_int
         implicit none
         type(c_ptr), value :: scope
@@ -198,33 +198,33 @@ interface
         integer(c_int), value :: i
         integer(c_int), value :: id_type
         type(c_ptr), intent(out) :: dev_id
-    end function qv_scope_device_id_c
+    end function qv_device_id_c
 
     integer(c_int) &
-    function qv_scope_bind_push_c(scope) &
-        bind(c, name='qv_scope_bind_push')
+    function qv_bind_push_c(scope) &
+        bind(c, name='qv_bind_push')
         use, intrinsic :: iso_c_binding, only: c_ptr, c_int
         implicit none
         type(c_ptr), value :: scope
-    end function qv_scope_bind_push_c
+    end function qv_bind_push_c
 
     integer(c_int) &
-    function qv_scope_bind_pop_c(scope) &
-        bind(c, name='qv_scope_bind_pop')
+    function qv_bind_pop_c(scope) &
+        bind(c, name='qv_bind_pop')
         use, intrinsic :: iso_c_binding, only: c_ptr, c_int
         implicit none
         type(c_ptr), value :: scope
-    end function qv_scope_bind_pop_c
+    end function qv_bind_pop_c
 
     integer(c_int) &
-    function qv_scope_bind_string_c(scope, sformat, str) &
-        bind(c, name='qv_scope_bind_string')
+    function qv_bind_string_c(scope, sformat, str) &
+        bind(c, name='qv_bind_string')
         use, intrinsic :: iso_c_binding, only: c_ptr, c_int
         implicit none
         type(c_ptr), value :: scope
         integer(c_int), value :: sformat
         type(c_ptr), intent(out) :: str
-    end function qv_scope_bind_string_c
+    end function qv_bind_string_c
 
     type(c_ptr) &
     function qv_strerr_c(ec) &
@@ -266,25 +266,25 @@ contains
         info = qv_version_c(major, minor, patch)
     end subroutine qv_version
 
-    subroutine qv_process_scope_get(iscope, flags, scope, info)
+    subroutine qv_process_scope(iscope, flags, scope, info)
         use, intrinsic :: iso_c_binding, only: c_ptr, c_long_long, c_int
         implicit none
         integer(c_int), value :: iscope
         integer(c_long_long), value :: flags
         type(c_ptr), intent(out) :: scope
         integer(c_int), intent(out) :: info
-        info = qv_process_scope_get_c(iscope, flags, scope)
-    end subroutine qv_process_scope_get
+        info = qv_process_scope_c(iscope, flags, scope)
+    end subroutine qv_process_scope
 
-    subroutine qv_scope_free(scope, info)
+    subroutine qv_free(scope, info)
         use, intrinsic :: iso_c_binding, only: c_ptr, c_int
         implicit none
         type(c_ptr), value :: scope
         integer(c_int), intent(out) :: info
-        info = qv_scope_free_c(scope)
-    end subroutine qv_scope_free
+        info = qv_free_c(scope)
+    end subroutine qv_free
 
-    subroutine qv_scope_split( &
+    subroutine qv_split( &
         scope, npieces, group_id, subscope, info &
     )
         use, intrinsic :: iso_c_binding, only: c_ptr, c_int
@@ -294,12 +294,12 @@ contains
         integer(c_int), value :: group_id
         type(c_ptr), intent(out) :: subscope
         integer(c_int), intent(out) :: info
-        info = qv_scope_split_c( &
+        info = qv_split_c( &
             scope, npieces, group_id, subscope &
         )
-    end subroutine qv_scope_split
+    end subroutine qv_split
 
-    subroutine qv_scope_split_at( &
+    subroutine qv_split_at( &
         scope, obj_type, group_id, subscope, info &
     )
         use, intrinsic :: iso_c_binding, only: c_ptr, c_int
@@ -309,48 +309,48 @@ contains
         integer(c_int), value :: group_id
         type(c_ptr), intent(out) :: subscope
         integer(c_int), intent(out) :: info
-        info = qv_scope_split_at_c( &
+        info = qv_split_at_c( &
             scope, obj_type, group_id, subscope &
         )
-    end subroutine qv_scope_split_at
+    end subroutine qv_split_at
 
-    subroutine qv_scope_hw_obj_count(scope, obj, n, info)
+    subroutine qv_hw_obj_count(scope, obj, n, info)
         use, intrinsic :: iso_c_binding, only: c_ptr, c_int
         implicit none
         type(c_ptr), value :: scope
         integer(c_int), value :: obj
         integer(c_int), intent(out) :: n
         integer(c_int), intent(out) :: info
-        info = qv_scope_hw_obj_count_c(scope, obj, n)
-    end subroutine qv_scope_hw_obj_count
+        info = qv_hw_obj_count_c(scope, obj, n)
+    end subroutine qv_hw_obj_count
 
-    subroutine qv_scope_group_rank(scope, taskid, info)
+    subroutine qv_group_rank(scope, taskid, info)
         use, intrinsic :: iso_c_binding, only: c_ptr, c_int
         implicit none
         type(c_ptr), value :: scope
         integer(c_int), intent(out) :: taskid
         integer(c_int), intent(out) :: info
-        info = qv_scope_group_rank_c(scope, taskid)
-    end subroutine qv_scope_group_rank
+        info = qv_group_rank_c(scope, taskid)
+    end subroutine qv_group_rank
 
-    subroutine qv_scope_group_size(scope, ntasks, info)
+    subroutine qv_group_size(scope, ntasks, info)
         use, intrinsic :: iso_c_binding, only: c_ptr, c_int
         implicit none
         type(c_ptr), value :: scope
         integer(c_int), intent(out) :: ntasks
         integer(c_int), intent(out) :: info
-        info = qv_scope_group_size_c(scope, ntasks)
-    end subroutine qv_scope_group_size
+        info = qv_group_size_c(scope, ntasks)
+    end subroutine qv_group_size
 
-    subroutine qv_scope_barrier(scope, info)
+    subroutine qv_barrier(scope, info)
         use, intrinsic :: iso_c_binding, only: c_ptr, c_int
         implicit none
         type(c_ptr), value :: scope
         integer(c_int), intent(out) :: info
-        info = qv_scope_barrier_c(scope)
-    end subroutine qv_scope_barrier
+        info = qv_barrier_c(scope)
+    end subroutine qv_barrier
 
-    subroutine qv_scope_device_id( &
+    subroutine qv_device_id( &
         scope, dev_obj, i, id_type, dev_id, info &
     )
         use, intrinsic :: iso_c_binding, only: c_ptr, c_int
@@ -366,7 +366,7 @@ contains
         integer(c_size_t) :: strlen
         character, pointer, dimension(:) :: fstrp
 
-        info = qv_scope_device_id_c( &
+        info = qv_device_id_c( &
             scope, dev_obj, i, id_type, cstr &
         )
         ! Now deal with the string
@@ -375,25 +375,25 @@ contains
         allocate(character(strlen) :: dev_id(1))
         dev_id = fstrp
         call qvif_free_c(cstr)
-    end subroutine qv_scope_device_id
+    end subroutine qv_device_id
 
-    subroutine qv_scope_bind_push(scope, info)
+    subroutine qv_bind_push(scope, info)
         use, intrinsic :: iso_c_binding, only: c_ptr, c_int
         implicit none
         type(c_ptr), value :: scope
         integer(c_int), intent(out) :: info
-        info = qv_scope_bind_push_c(scope)
-    end subroutine qv_scope_bind_push
+        info = qv_bind_push_c(scope)
+    end subroutine qv_bind_push
 
-    subroutine qv_scope_bind_pop(scope, info)
+    subroutine qv_bind_pop(scope, info)
         use, intrinsic :: iso_c_binding, only: c_ptr, c_int
         implicit none
         type(c_ptr), value :: scope
         integer(c_int), intent(out) :: info
-        info = qv_scope_bind_pop_c(scope)
-    end subroutine qv_scope_bind_pop
+        info = qv_bind_pop_c(scope)
+    end subroutine qv_bind_pop
 
-    subroutine qv_scope_bind_string(scope, sformat, fstr, info)
+    subroutine qv_bind_string(scope, sformat, fstr, info)
         use, intrinsic :: iso_c_binding, only: c_ptr, c_int, c_size_t
         implicit none
         type(c_ptr), value :: scope
@@ -405,7 +405,7 @@ contains
         integer(c_size_t) :: strlen
         character, pointer, dimension(:) :: fstrp
 
-        info = qv_scope_bind_string_c(scope, sformat, cstr)
+        info = qv_bind_string_c(scope, sformat, cstr)
         ! Now deal with the string
         strlen = qvif_strlen_c(cstr)
         call c_f_pointer(cstr, fstrp, [strlen])

--- a/src/quo-vadis-mpi.cc
+++ b/src/quo-vadis-mpi.cc
@@ -35,7 +35,7 @@ qvi_mpi_scope_get_f2c(
     qv_scope_t **scope
 ) {
     MPI_Comm c_comm = MPI_Comm_f2c(comm);
-    return qv_mpi_scope_get(c_comm, iscope, flags, scope);
+    return qv_mpi_scope(c_comm, iscope, flags, scope);
 }
 
 int
@@ -44,7 +44,7 @@ qvi_mpi_scope_comm_dup_f2c(
     MPI_Fint *comm
 ) {
     MPI_Comm c_comm = MPI_COMM_NULL;
-    const int rc = qv_mpi_scope_comm_dup(scope, &c_comm);
+    const int rc = qv_mpi_comm_dup(scope, &c_comm);
     *comm = MPI_Comm_c2f(c_comm);
     return rc;
 }
@@ -70,7 +70,7 @@ qvi_mpi_scope_get(
 }
 
 int
-qv_mpi_scope_get(
+qv_mpi_scope(
     MPI_Comm comm,
     qv_scope_intrinsic_t iscope,
     qv_scope_flags_t flags,
@@ -94,7 +94,7 @@ qvi_mpi_scope_comm_dup(
 }
 
 int
-qv_mpi_scope_comm_dup(
+qv_mpi_comm_dup(
     qv_scope_t *scope,
     MPI_Comm *comm
 ) {

--- a/src/quo-vadis-thread.cc
+++ b/src/quo-vadis-thread.cc
@@ -98,7 +98,7 @@ split_color_fixup(
 }
 
 int
-qv_thread_scope_split(
+qv_thread_split(
     qv_scope_t *scope,
     int npieces,
     int *kcolors,
@@ -123,7 +123,7 @@ qv_thread_scope_split(
 }
 
 int
-qv_thread_scope_split_at(
+qv_thread_split_at(
     qv_scope_t *scope,
     qv_hw_obj_type_t type,
     int *kcolors,
@@ -145,7 +145,7 @@ qv_thread_scope_split_at(
 }
 
 int
-qv_thread_scopes_free(
+qv_thread_free(
     int nscopes,
     qv_scope_t **scopes
 ) {

--- a/src/quo-vadis.cc
+++ b/src/quo-vadis.cc
@@ -51,7 +51,7 @@ qvi_process_scope_get(
 }
 
 int
-qv_process_scope_get(
+qv_process_scope(
     qv_scope_intrinsic_t iscope,
     qv_scope_flags_t flags,
     qv_scope_t **scope
@@ -66,7 +66,7 @@ qv_process_scope_get(
 }
 
 int
-qv_scope_bind_push(
+qv_bind_push(
     qv_scope_t *scope
 ) {
     if (qvi_unlikely(!scope)) {
@@ -79,7 +79,7 @@ qv_scope_bind_push(
 }
 
 int
-qv_scope_bind_pop(
+qv_bind_pop(
     qv_scope_t *scope
 ) {
     if (qvi_unlikely(!scope)) {
@@ -92,7 +92,7 @@ qv_scope_bind_pop(
 }
 
 int
-qv_scope_bind_string(
+qv_bind_string(
     qv_scope_t *scope,
     qv_bind_string_flags_t flags,
     char **str
@@ -107,7 +107,7 @@ qv_scope_bind_string(
 }
 
 int
-qv_scope_free(
+qv_free(
     qv_scope_t *scope
 ) {
     // Just accept NULL like free() does.
@@ -122,7 +122,7 @@ qv_scope_free(
 }
 
 int
-qv_scope_hw_obj_count(
+qv_hw_obj_count(
     qv_scope_t *scope,
     qv_hw_obj_type_t obj,
     int *nobjs
@@ -138,7 +138,7 @@ qv_scope_hw_obj_count(
 }
 
 int
-qv_scope_group_rank(
+qv_group_rank(
     qv_scope_t *scope,
     int *rank
 ) {
@@ -153,7 +153,7 @@ qv_scope_group_rank(
 }
 
 int
-qv_scope_group_size(
+qv_group_size(
     qv_scope_t *scope,
     int *group_size
 ) {
@@ -168,7 +168,7 @@ qv_scope_group_size(
 }
 
 int
-qv_scope_barrier(
+qv_barrier(
     qv_scope_t *scope
 ) {
     if (qvi_unlikely(!scope)) {
@@ -182,7 +182,7 @@ qv_scope_barrier(
 
 // TODO(skg) Add Fortran interface.
 int
-qv_scope_create(
+qv_create_scope(
     qv_scope_t *scope,
     qv_scope_flags_t flags,
     qv_hw_obj_type_t type,
@@ -199,7 +199,7 @@ qv_scope_create(
 }
 
 int
-qv_scope_split(
+qv_split(
     qv_scope_t *scope,
     int npieces,
     int group_id,
@@ -218,7 +218,7 @@ qv_scope_split(
 }
 
 int
-qv_scope_split_at(
+qv_split_at(
     qv_scope_t *scope,
     qv_hw_obj_type_t type,
     int group_id,
@@ -234,7 +234,7 @@ qv_scope_split_at(
 }
 
 int
-qv_scope_device_id(
+qv_device_id(
     qv_scope_t *scope,
     qv_hw_obj_type_t dev_obj,
     int dev_index,

--- a/tests/common-test-utils.cc
+++ b/tests/common-test-utils.cc
@@ -182,9 +182,9 @@ public:
         do {
             m_initialized = false;
 
-            rc = qv_mpi_scope_comm_dup(scope, &m_comm);
+            rc = qv_mpi_comm_dup(scope, &m_comm);
             if (rc != QV_SUCCESS) {
-                ers = "qv_mpi_scope_comm_dup";
+                ers = "qv_mpi_comm_dup";
                 rc = MPI_ERR_COMM;
                 break;
             }
@@ -248,16 +248,16 @@ ctu_scope_size_rank(
     char const *ers = NULL;
 
     int sgsize;
-    int rc = qv_scope_group_size(scope, &sgsize);
+    int rc = qv_group_size(scope, &sgsize);
     if (rc != QV_SUCCESS) {
-        ers = "qv_scope_group_size() failed";
+        ers = "qv_group_size() failed";
         ctu_panic("%s (rc=%s)", ers, qv_strerr(rc));
     }
 
     int sgrank;
-    rc = qv_scope_group_rank(scope, &sgrank);
+    rc = qv_group_rank(scope, &sgrank);
     if (rc != QV_SUCCESS) {
-        ers = "qv_scope_group_rank() failed";
+        ers = "qv_group_rank() failed";
         ctu_panic("%s (rc=%s)", ers, qv_strerr(rc));
     }
 
@@ -271,9 +271,9 @@ ctu_current_binding(
     char const *ers = NULL;
     // Get current binding.
     char *cpusets;
-    int rc = qv_scope_bind_string(scope, QV_BIND_STRING_LOGICAL, &cpusets);
+    int rc = qv_bind_string(scope, QV_BIND_STRING_LOGICAL, &cpusets);
     if (rc != QV_SUCCESS) {
-        ers = "qv_scope_bind_string() failed";
+        ers = "qv_bind_string() failed";
         ctu_panic("%s (rc=%s)", ers, qv_strerr(rc));
     }
     std::string result(cpusets);
@@ -287,7 +287,7 @@ ctu_scope_cpuset(
 ) {
     char const *ers = NULL;
     // Change binding to get the scope's underlying cpuset.
-    int rc = qv_scope_bind_push(scope);
+    int rc = qv_bind_push(scope);
     if (rc != QV_SUCCESS) {
         ers = "qv_bind_push() failed";
         ctu_panic("%s (rc=%s)", ers, qv_strerr(rc));
@@ -295,7 +295,7 @@ ctu_scope_cpuset(
     // Get the current binding after push.
     auto result = ctu_current_binding(scope);
     // Pop to not affect other calls related to the scope.
-    rc = qv_scope_bind_pop(scope);
+    rc = qv_bind_pop(scope);
     if (rc != QV_SUCCESS) {
         ers = "qv_bind_pop() failed";
         ctu_panic("%s (rc=%s)", ers, qv_strerr(rc));
@@ -394,12 +394,12 @@ ctu_emit_host_hw_info(
 
     for (size_t i = 0; i < ctu_hw_obj_name_to_type_tab_size; ++i) {
         int n;
-        int rc = qv_scope_hw_obj_count(
+        int rc = qv_hw_obj_count(
             scope, ctu_hw_obj_name_to_type_tab[i].type, &n
         );
         if (rc != QV_SUCCESS) {
             ctu_panic(
-                "qv_scope_hw_obj_count(%s) failed\n",
+                "qv_hw_obj_count(%s) failed\n",
                 ctu_hw_obj_name_to_type_tab[i].name
             );
         }
@@ -422,9 +422,9 @@ ctu_emit_device_info(
     const std::string myid = reporter.id();
     // Get number of devices.
     int ndevs;
-    int rc = qv_scope_hw_obj_count(scope, dev_type, &ndevs);
+    int rc = qv_hw_obj_count(scope, dev_type, &ndevs);
     if (rc != QV_SUCCESS) {
-        const char *ers = "qv_scope_hw_obj_count() failed";
+        const char *ers = "qv_hw_obj_count() failed";
         ctu_panic("%s (rc=%s)", ers, qv_strerr(rc));
     }
 
@@ -443,7 +443,7 @@ ctu_emit_device_info(
     for (int i = 0; i < ndevs; ++i) {
         for (size_t j = 0; j < ctu_devid_name_to_id_tab_size; ++j) {
             char *devids = NULL;
-            int rc = qv_scope_device_id(
+            int rc = qv_device_id(
                 scope,
                 dev_type,
                 i,
@@ -451,7 +451,7 @@ ctu_emit_device_info(
                 &devids
             );
             if (rc != QV_SUCCESS) {
-                const char *ers = "qv_scope_device_id() failed";
+                const char *ers = "qv_device_id() failed";
                 ctu_panic("%s (rc=%s)", ers, qv_strerr(rc));
             }
             reporter.add(

--- a/tests/test-mpi-api.c
+++ b/tests/test-mpi-api.c
@@ -43,11 +43,11 @@ main(
     }
 
     qv_scope_t *world_scope = NULL;
-    rc = qv_mpi_scope_get(
+    rc = qv_mpi_scope(
         comm, QV_SCOPE_USER, QV_SCOPE_FLAG_NONE, &world_scope
     );
     if (rc != QV_SUCCESS) {
-        ers = "qv_mpi_scope_get() failed";
+        ers = "qv_mpi_scope() failed";
         ctu_panic("%s (rc=%s)", ers, qv_strerr(rc));
     }
 
@@ -57,9 +57,9 @@ main(
     );
 
     MPI_Comm wscope_comm = MPI_COMM_NULL;
-    rc = qv_mpi_scope_comm_dup(world_scope, &wscope_comm);
+    rc = qv_mpi_comm_dup(world_scope, &wscope_comm);
     if (rc != QV_SUCCESS) {
-        ers = "qv_mpi_scope_comm_dup() failed";
+        ers = "qv_mpi_comm_dup() failed";
         ctu_panic("%s (rc=%s)", ers, qv_strerr(rc));
     }
 
@@ -88,18 +88,18 @@ main(
     }
 
     qv_scope_t *sub_scope = NULL;
-    rc = qv_scope_split(
+    rc = qv_split(
         world_scope, wsize, wrank, &sub_scope
     );
     if (rc != QV_SUCCESS) {
-        ers = "qv_scope_split() failed";
+        ers = "qv_split() failed";
         ctu_panic("%s (rc=%s)", ers, qv_strerr(rc));
     }
 
     MPI_Comm split_wscope_comm = MPI_COMM_NULL;
-    rc = qv_mpi_scope_comm_dup(sub_scope, &split_wscope_comm);
+    rc = qv_mpi_comm_dup(sub_scope, &split_wscope_comm);
     if (rc != QV_SUCCESS) {
-        ers = "qv_mpi_scope_comm_dup() failed";
+        ers = "qv_mpi_comm_dup() failed";
         ctu_panic("%s (rc=%s)", ers, qv_strerr(rc));
     }
 
@@ -132,15 +132,15 @@ main(
         split_wscope_size, wsize
     );
 
-    rc = qv_scope_free(sub_scope);
+    rc = qv_free(sub_scope);
     if (rc != QV_SUCCESS) {
-        ers = "qv_scope_free() failed";
+        ers = "qv_free() failed";
         ctu_panic("%s (rc=%s)", ers, qv_strerr(rc));
     }
 
-    rc = qv_scope_free(world_scope);
+    rc = qv_free(world_scope);
     if (rc != QV_SUCCESS) {
-        ers = "qv_scope_free() failed";
+        ers = "qv_free() failed";
         ctu_panic("%s (rc=%s)", ers, qv_strerr(rc));
     }
 

--- a/tests/test-mpi-dev-split.c
+++ b/tests/test-mpi-dev-split.c
@@ -28,34 +28,34 @@ main(
     }
     // Get base scope.
     qv_scope_t *base_scope;
-    rc = qv_mpi_scope_get(
+    rc = qv_mpi_scope(
         comm,
         QV_SCOPE_USER,
         QV_SCOPE_FLAG_NONE,
         &base_scope
     );
     if (rc != QV_SUCCESS) {
-        ers = "qv_mpi_scope_get() failed";
+        ers = "qv_mpi_scope() failed";
         ctu_panic("%s (rc=%s)", ers, qv_strerr(rc));
     }
     // Get my base_scope's size and my rank.
     int base_scope_size;
-    rc = qv_scope_group_size(
+    rc = qv_group_size(
         base_scope,
         &base_scope_size
     );
     if (rc != QV_SUCCESS) {
-        ers = "qv_scope_group_size() failed";
+        ers = "qv_group_size() failed";
         ctu_panic("%s (rc=%s)", ers, qv_strerr(rc));
     }
 
     int base_scope_rank;
-    rc = qv_scope_group_rank(
+    rc = qv_group_rank(
         base_scope,
         &base_scope_rank
     );
     if (rc != QV_SUCCESS) {
-        ers = "qv_scope_group_rank() failed";
+        ers = "qv_group_rank() failed";
         ctu_panic("%s (rc=%s)", ers, qv_strerr(rc));
     }
 
@@ -78,25 +78,25 @@ main(
     }
     // Split the base scope evenly across workers.
     qv_scope_t *rank_scope;
-    rc = qv_scope_split(
+    rc = qv_split(
         base_scope,
         base_scope_size,
         base_scope_rank,
         &rank_scope
     );
     if (rc != QV_SUCCESS) {
-        ers = "qv_scope_split() failed";
+        ers = "qv_split() failed";
         ctu_panic("%s (rc=%s)", ers, qv_strerr(rc));
     }
     // Get number of tested devices in my rank_scope.
     for (int i = 0; i < ndevs_tested; ++i) {
-        rc = qv_scope_hw_obj_count(
+        rc = qv_hw_obj_count(
             rank_scope,
             devs_tested[i],
             &rank_ndev[i]
         );
         if (rc != QV_SUCCESS) {
-            ers = "qv_scope_hw_obj_count() failed";
+            ers = "qv_hw_obj_count() failed";
             ctu_panic("%s (rc=%s)", ers, qv_strerr(rc));
         }
     }
@@ -118,20 +118,20 @@ main(
             ctu_emit(rank_scope, CTU_SCOPE_KIND_MPI, "");
             ctu_emit(rank_scope, CTU_SCOPE_KIND_MPI, "");
         }
-        rc = qv_scope_barrier(base_scope);
+        rc = qv_barrier(base_scope);
         if (rc != QV_SUCCESS) {
-            ers = "qv_scope_barrier() failed";
+            ers = "qv_barrier() failed";
             ctu_panic("%s (rc=%s)", ers, qv_strerr(rc));
         }
     }
     // Verify results.
     for (int i = 0; i < ndevs_tested; ++i) {
         // Get total number of GPUs in base_scope.
-        rc = qv_scope_hw_obj_count(
+        rc = qv_hw_obj_count(
             base_scope, devs_tested[i], &base_ndev[i]
         );
         if (rc != QV_SUCCESS) {
-            ers = "qv_scope_hw_obj_count() failed";
+            ers = "qv_hw_obj_count() failed";
             ctu_panic("%s (rc=%s)", ers, qv_strerr(rc));
         }
         int total_ndevs;
@@ -158,8 +158,8 @@ main(
         }
     }
     // Cleanup.
-    qv_scope_free(rank_scope);
-    qv_scope_free(base_scope);
+    qv_free(rank_scope);
+    qv_free(base_scope);
 
     MPI_Finalize();
 

--- a/tests/test-mpi-double-split.c
+++ b/tests/test-mpi-double-split.c
@@ -16,14 +16,14 @@ emit_gpu_info(
     char const *ers = NULL;
 
     qv_scope_t *split_at_gpu;
-    int rc = qv_scope_split_at(
+    int rc = qv_split_at(
         base_scope,
         QV_HW_OBJ_GPU,
         QV_SCOPE_SPLIT_PACKED,
         &split_at_gpu
     );
     if (rc != QV_SUCCESS) {
-        ers = "qv_scope_split_at() failed";
+        ers = "qv_split_at() failed";
         ctu_panic("%s (rc=%s)", ers, qv_strerr(rc));
     }
 
@@ -37,16 +37,16 @@ emit_gpu_info(
         else {
             ctu_emit(split_at_gpu, CTU_SCOPE_KIND_MPI, "");
         }
-        rc = qv_scope_barrier(base_scope);
+        rc = qv_barrier(base_scope);
         if (rc != QV_SUCCESS) {
-            ers = "qv_scope_barrier() failed";
+            ers = "qv_barrier() failed";
             ctu_panic("%s (rc=%s)", ers, qv_strerr(rc));
         }
     }
 
-    rc = qv_scope_free(split_at_gpu);
+    rc = qv_free(split_at_gpu);
     if (rc != QV_SUCCESS) {
-        ers = "qv_scope_free() failed";
+        ers = "qv_free() failed";
         ctu_panic("%s (rc=%s)", ers, qv_strerr(rc));
     }
 }
@@ -66,35 +66,35 @@ main(
     }
 
     qv_scope_t *base_scope;
-    rc = qv_mpi_scope_get(
+    rc = qv_mpi_scope(
         comm,
         QV_SCOPE_USER,
         QV_SCOPE_FLAG_NONE,
         &base_scope
     );
     if (rc != QV_SUCCESS) {
-        ers = "qv_mpi_scope_get() failed";
+        ers = "qv_mpi_scope() failed";
         ctu_panic("%s (rc=%s)", ers, qv_strerr(rc));
     }
 
     // Get my base_scope's size and my rank.
     int base_scope_size;
-    rc = qv_scope_group_size(
+    rc = qv_group_size(
         base_scope,
         &base_scope_size
     );
     if (rc != QV_SUCCESS) {
-        ers = "qv_scope_group_size() failed";
+        ers = "qv_group_size() failed";
         ctu_panic("%s (rc=%s)", ers, qv_strerr(rc));
     }
 
     int base_scope_rank;
-    rc = qv_scope_group_rank(
+    rc = qv_group_rank(
         base_scope,
         &base_scope_rank
     );
     if (rc != QV_SUCCESS) {
-        ers = "qv_scope_group_rank() failed";
+        ers = "qv_group_rank() failed";
         ctu_panic("%s (rc=%s)", ers, qv_strerr(rc));
     }
 
@@ -107,22 +107,22 @@ main(
         else {
             ctu_emit(base_scope, CTU_SCOPE_KIND_MPI, "");
         }
-        rc = qv_scope_barrier(base_scope);
+        rc = qv_barrier(base_scope);
         if (rc != QV_SUCCESS) {
-            ers = "qv_scope_barrier() failed";
+            ers = "qv_barrier() failed";
             ctu_panic("%s (rc=%s)", ers, qv_strerr(rc));
         }
     }
 
     qv_scope_t *split_at_numa;
-    rc = qv_scope_split_at(
+    rc = qv_split_at(
         base_scope,
         QV_HW_OBJ_NUMANODE,
         QV_SCOPE_SPLIT_PACKED,
         &split_at_numa
     );
     if (rc != QV_SUCCESS) {
-        ers = "qv_scope_split_at() failed";
+        ers = "qv_split_at() failed";
         ctu_panic("%s (rc=%s)", ers, qv_strerr(rc));
     }
 
@@ -135,32 +135,32 @@ main(
         else {
             ctu_emit(split_at_numa, CTU_SCOPE_KIND_MPI, "");
         }
-        rc = qv_scope_barrier(base_scope);
+        rc = qv_barrier(base_scope);
         if (rc != QV_SUCCESS) {
-            ers = "qv_scope_barrier() failed";
+            ers = "qv_barrier() failed";
             ctu_panic("%s (rc=%s)", ers, qv_strerr(rc));
         }
     }
 
     int ntask_per_numa;
-    rc = qv_scope_group_size(
+    rc = qv_group_size(
         split_at_numa,
         &ntask_per_numa
     );
     if (rc != QV_SUCCESS) {
-        ers = "qv_scope_group_size() failed";
+        ers = "qv_group_size() failed";
         ctu_panic("%s (rc=%s)", ers, qv_strerr(rc));
     }
 
     qv_scope_t *split_cores_from_numa;
-    rc = qv_scope_split(
+    rc = qv_split(
         split_at_numa,
         ntask_per_numa,
         QV_SCOPE_SPLIT_PACKED,
         &split_cores_from_numa
     );
     if (rc != QV_SUCCESS) {
-        ers = "qv_scope_split() failed";
+        ers = "qv_split() failed";
         ctu_panic("%s (rc=%s)", ers, qv_strerr(rc));
     }
 
@@ -173,21 +173,21 @@ main(
         else {
             ctu_emit(split_cores_from_numa, CTU_SCOPE_KIND_MPI, "");
         }
-        rc = qv_scope_barrier(base_scope);
+        rc = qv_barrier(base_scope);
         if (rc != QV_SUCCESS) {
-            ers = "qv_scope_barrier() failed";
+            ers = "qv_barrier() failed";
             ctu_panic("%s (rc=%s)", ers, qv_strerr(rc));
         }
     }
 
     // How many GPUs do we have?
     int ngpus;
-    rc = qv_scope_hw_obj_count(
+    rc = qv_hw_obj_count(
         base_scope, QV_HW_OBJ_GPU, &ngpus
 
     );
     if (rc != QV_SUCCESS) {
-        ers = "qv_scope_hw_obj_count() failed";
+        ers = "qv_hw_obj_count() failed";
         ctu_panic("%s (rc=%s)", ers, qv_strerr(rc));
     }
 
@@ -196,21 +196,21 @@ main(
     }
 
     // Free base_scope first to test scope free out-of-order operations.
-    rc = qv_scope_free(base_scope);
+    rc = qv_free(base_scope);
     if (rc != QV_SUCCESS) {
-        ers = "qv_scope_free() failed";
+        ers = "qv_free() failed";
         ctu_panic("%s (rc=%s)", ers, qv_strerr(rc));
     }
 
-    rc = qv_scope_free(split_at_numa);
+    rc = qv_free(split_at_numa);
     if (rc != QV_SUCCESS) {
-        ers = "qv_scope_free() failed";
+        ers = "qv_free() failed";
         ctu_panic("%s (rc=%s)", ers, qv_strerr(rc));
     }
 
-    rc = qv_scope_free(split_cores_from_numa);
+    rc = qv_free(split_cores_from_numa);
     if (rc != QV_SUCCESS) {
-        ers = "qv_scope_free() failed";
+        ers = "qv_free() failed";
         ctu_panic("%s (rc=%s)", ers, qv_strerr(rc));
     }
 

--- a/tests/test-mpi-fortapi.f90
+++ b/tests/test-mpi-fortapi.f90
@@ -44,7 +44,7 @@ program mpi_fortapi
         print *, 'cwsize', cwsize
     end if
 
-    call qv_mpi_scope_get( &
+    call qv_mpi_scope( &
         MPI_COMM_WORLD, QV_SCOPE_USER, &
         QV_SCOPE_FLAG_NONE, scope_user, info &
     )
@@ -52,7 +52,7 @@ program mpi_fortapi
         error stop
     end if
 
-    call qv_mpi_scope_comm_dup(scope_user, scope_comm, info)
+    call qv_mpi_comm_dup(scope_user, scope_comm, info)
     if (info .ne. QV_SUCCESS) then
         error stop
     end if
@@ -70,51 +70,51 @@ program mpi_fortapi
         error stop
     end if
 
-    call qv_scope_group_size(scope_user, sgsize, info)
+    call qv_group_size(scope_user, sgsize, info)
     if (info .ne. QV_SUCCESS) then
         error stop
     end if
     print *, 'sgsize', sgsize
 
-    call qv_scope_group_rank(scope_user, sgrank, info)
+    call qv_group_rank(scope_user, sgrank, info)
     if (info .ne. QV_SUCCESS) then
         error stop
     end if
     print *, 'sgrank', sgrank
 
-    call qv_scope_hw_obj_count(scope_user, QV_HW_OBJ_CORE, n_cores, info)
+    call qv_hw_obj_count(scope_user, QV_HW_OBJ_CORE, n_cores, info)
     if (info .ne. QV_SUCCESS) then
         error stop
     end if
     print *, 'ncores', n_cores
 
-    call qv_scope_split(scope_user, 2, sgrank, sub_scope, info)
+    call qv_split(scope_user, 2, sgrank, sub_scope, info)
 
-    call qv_scope_bind_push(sub_scope, info)
+    call qv_bind_push(sub_scope, info)
     if (info .ne. QV_SUCCESS) then
         error stop
     end if
 
-    call qv_scope_bind_string(sub_scope, QV_BIND_STRING_LOGICAL, bstr, info)
+    call qv_bind_string(sub_scope, QV_BIND_STRING_LOGICAL, bstr, info)
     if (info .ne. QV_SUCCESS) then
         error stop
     end if
     print *, 'bstr ', bstr
     deallocate(bstr)
 
-    call qv_scope_bind_pop(sub_scope, info)
+    call qv_bind_pop(sub_scope, info)
     if (info .ne. QV_SUCCESS) then
         error stop
     end if
 
-    call qv_scope_hw_obj_count(scope_user, QV_HW_OBJ_GPU, n_gpu, info)
+    call qv_hw_obj_count(scope_user, QV_HW_OBJ_GPU, n_gpu, info)
     if (info .ne. QV_SUCCESS) then
         error stop
     end if
     print *, 'ngpu', n_gpu
 
     do n = 0, n_gpu - 1
-        call qv_scope_device_id( &
+        call qv_device_id( &
             scope_user, QV_HW_OBJ_GPU, n, &
             QV_DEVICE_ID_PCI_BUS_ID, dev_pci, info &
         )
@@ -132,12 +132,12 @@ program mpi_fortapi
     strerr => qv_strerr(QV_ERR_OOR)
     print *, 'err oor is ', strerr
 
-    call qv_scope_free(scope_user, info)
+    call qv_free(scope_user, info)
     if (info .ne. QV_SUCCESS) then
         error stop
     end if
 
-    call qv_scope_free(sub_scope, info)
+    call qv_free(sub_scope, info)
     if (info .ne. QV_SUCCESS) then
         error stop
     end if

--- a/tests/test-mpi-init.c
+++ b/tests/test-mpi-init.c
@@ -22,17 +22,17 @@ main(
     }
 
     qv_scope_t *scope = NULL;
-    rc = qv_mpi_scope_get(
+    rc = qv_mpi_scope(
         comm, QV_SCOPE_USER, QV_SCOPE_FLAG_NONE, &scope
     );
     if (rc != QV_SUCCESS) {
-        ers = "qv_mpi_scope_get() failed";
+        ers = "qv_mpi_scope() failed";
         ctu_panic("%s (rc=%s)", ers, qv_strerr(rc));
     }
 
-    rc = qv_scope_free(scope);
+    rc = qv_free(scope);
     if (rc != QV_SUCCESS) {
-        ers = "qv_scope_free() failed";
+        ers = "qv_free() failed";
         ctu_panic("%s (rc=%s)", ers, qv_strerr(rc));
     }
 

--- a/tests/test-mpi-phases.c
+++ b/tests/test-mpi-phases.c
@@ -68,25 +68,25 @@ main(
 
     /* Get base scope: RM-given resources */
     qv_scope_t *base_scope;
-    rc = qv_mpi_scope_get(
+    rc = qv_mpi_scope(
         comm,
         QV_SCOPE_USER,
         QV_SCOPE_FLAG_NONE,
         &base_scope
     );
     if (rc != QV_SUCCESS) {
-        ers = "qv_mpi_scope_get() failed";
+        ers = "qv_mpi_scope() failed";
         ctu_panic("%s (rc=%s)", ers, qv_strerr(rc));
     }
 
     int ncores;
-    rc = qv_scope_hw_obj_count(
+    rc = qv_hw_obj_count(
         base_scope,
         QV_HW_OBJ_CORE,
         &ncores
     );
     if (rc != QV_SUCCESS) {
-        ers = "qv_scope_hw_obj_count() failed";
+        ers = "qv_hw_obj_count() failed";
         ctu_panic("%s (rc=%s)", ers, qv_strerr(rc));
     }
 
@@ -94,7 +94,7 @@ main(
       printf("\n===Phase 1: Regular split===\n");
 
     char *binds;
-    rc = qv_scope_bind_string(base_scope, QV_BIND_STRING_LOGICAL, &binds);
+    rc = qv_bind_string(base_scope, QV_BIND_STRING_LOGICAL, &binds);
     if (rc != QV_SUCCESS) {
         ers = "qv_bind_get_list_as_string() failed";
         ctu_panic("%s (rc=%s)", ers, qv_strerr(rc));
@@ -105,7 +105,7 @@ main(
 
     /* Split the base scope evenly across workers */
     qv_scope_t *sub_scope;
-    rc = qv_scope_split(
+    rc = qv_split(
         base_scope,
         wsize,        // Number of workers
 #ifdef USE_CLOSE
@@ -116,18 +116,18 @@ main(
         &sub_scope
     );
     if (rc != QV_SUCCESS) {
-        ers = "qv_scope_split() failed";
+        ers = "qv_split() failed";
         ctu_panic("%s (rc=%s)", ers, qv_strerr(rc));
     }
 
     /* What resources did I get? */
-    rc = qv_scope_hw_obj_count(
+    rc = qv_hw_obj_count(
         sub_scope,
         QV_HW_OBJ_CORE,
         &ncores
     );
     if (rc != QV_SUCCESS) {
-        ers = "qv_scope_hw_obj_count() failed";
+        ers = "qv_hw_obj_count() failed";
         ctu_panic("%s (rc=%s)", ers, qv_strerr(rc));
     }
 
@@ -135,14 +135,14 @@ main(
      * Phase 1: Everybody works
      ***************************************/
 
-    rc = qv_scope_bind_push(sub_scope);
+    rc = qv_bind_push(sub_scope);
     if (rc != QV_SUCCESS) {
         ers = "qv_bind_push() failed";
         ctu_panic("%s (rc=%s)", ers, qv_strerr(rc));
     }
 
     /* Where did I end up? */
-    rc = qv_scope_bind_string(sub_scope, QV_BIND_STRING_LOGICAL, &binds);
+    rc = qv_bind_string(sub_scope, QV_BIND_STRING_LOGICAL, &binds);
     if (rc != QV_SUCCESS) {
         ers = "qv_bind_get_list_as_string() failed";
         ctu_panic("%s (rc=%s)", ers, qv_strerr(rc));
@@ -157,20 +157,20 @@ main(
 
     /* Launch one kernel per GPU */
     int ngpus;
-    rc = qv_scope_hw_obj_count(
+    rc = qv_hw_obj_count(
         sub_scope,
         QV_HW_OBJ_GPU,
         &ngpus
     );
     if (rc != QV_SUCCESS) {
-        ers = "qv_scope_hw_obj_count() failed";
+        ers = "qv_hw_obj_count() failed";
         ctu_panic("%s (rc=%s)", ers, qv_strerr(rc));
     }
     printf("[%d] Launching %d GPU kernels\n", wrank, ngpus);
 
     char *gpu;
     for (int i = 0; i < ngpus; i++) {
-        qv_scope_device_id(sub_scope, QV_HW_OBJ_GPU, i, QV_DEVICE_ID_PCI_BUS_ID, &gpu);
+        qv_device_id(sub_scope, QV_HW_OBJ_GPU, i, QV_DEVICE_ID_PCI_BUS_ID, &gpu);
         printf("GPU %d PCI Bus ID = %s\n", i, gpu);
         //cudaDeviceGetByPCIBusId(&dev, gpu);
         //cudaSetDevice(dev);
@@ -179,13 +179,13 @@ main(
     }
 #endif
 
-    rc = qv_scope_bind_pop(sub_scope);
+    rc = qv_bind_pop(sub_scope);
     if (rc != QV_SUCCESS) {
         ers = "qv_bind_pop() failed";
         ctu_panic("%s (rc=%s)", ers, qv_strerr(rc));
     }
 
-    rc = qv_scope_bind_string(base_scope, QV_BIND_STRING_LOGICAL, &binds);
+    rc = qv_bind_string(base_scope, QV_BIND_STRING_LOGICAL, &binds);
     if (rc != QV_SUCCESS) {
         ers = "qv_bind_get_list_as_string() failed";
         ctu_panic("%s (rc=%s)", ers, qv_strerr(rc));
@@ -194,7 +194,7 @@ main(
     free(binds);
 
     /* Keep printouts separate for each phase */
-    rc = qv_scope_barrier(base_scope);
+    rc = qv_barrier(base_scope);
     if (rc != QV_SUCCESS) {
       ers = "qv_context_barrier() failed";
       ctu_panic("%s (rc=%s)", ers, qv_strerr(rc));
@@ -210,7 +210,7 @@ main(
        then splitting over that number. Then,
        we could ask for a leader of each subscope.
        However, this does not guarantee a NUMA split.
-       Thus, we use qv_scope_split_at. */
+       Thus, we use qv_split_at. */
     if (wrank == 0)
       printf("\n===Phase 2: NUMA split===\n");
 
@@ -220,18 +220,18 @@ main(
 
     /* Get the number of NUMA domains so that we can
        specify the color/groupid of split_at */
-    rc = qv_scope_hw_obj_count(
+    rc = qv_hw_obj_count(
         base_scope,
         QV_HW_OBJ_NUMANODE,
         &nnumas
     );
     if (rc != QV_SUCCESS) {
-        ers = "qv_scope_hw_obj_count() failed";
+        ers = "qv_hw_obj_count() failed";
         ctu_panic("%s (rc=%s)", ers, qv_strerr(rc));
     }
 
     /* Split at NUMA domains */
-    rc = qv_scope_split_at(
+    rc = qv_split_at(
         base_scope,
         QV_HW_OBJ_NUMANODE,
 #ifdef USE_CLOSE
@@ -242,41 +242,41 @@ main(
         &numa_scope
     );
     if (rc != QV_SUCCESS) {
-        ers = "qv_scope_split_at() failed";
+        ers = "qv_split_at() failed";
         ctu_panic("%s (rc=%s)", ers, qv_strerr(rc));
     }
 
     /* Allow selecting a leader per NUMA */
-    rc = qv_scope_group_rank(
+    rc = qv_group_rank(
         numa_scope,
         &my_numa_rank
     );
     if (rc != QV_SUCCESS) {
-        ers = "qv_scope_group_rank() failed";
+        ers = "qv_group_rank() failed";
         ctu_panic("%s (rc=%s)", ers, qv_strerr(rc));
     }
 
     printf("[%d]: #NUMAs=%d numa_scope_id=%d\n",
        wrank, nnumas, my_numa_rank);
 
-    rc = qv_scope_bind_push(numa_scope);
+    rc = qv_bind_push(numa_scope);
     if (rc != QV_SUCCESS) {
         ers = "qv_bind_push() failed";
         ctu_panic("%s (rc=%s)", ers, qv_strerr(rc));
     }
 
     int my_nnumas;
-    rc = qv_scope_hw_obj_count(
+    rc = qv_hw_obj_count(
             numa_scope,
             QV_HW_OBJ_NUMANODE,
             &my_nnumas);
     if (rc != QV_SUCCESS) {
-        ers = "qv_scope_hw_obj_count() failed";
+        ers = "qv_hw_obj_count() failed";
         ctu_panic("%s (rc=%s)", ers, qv_strerr(rc));
     }
 
     /* Where did I end up? */
-    rc = qv_scope_bind_string(numa_scope, QV_BIND_STRING_LOGICAL, &binds);
+    rc = qv_bind_string(numa_scope, QV_BIND_STRING_LOGICAL, &binds);
     if (rc != QV_SUCCESS) {
         ers = "qv_bind_get_list_as_string() failed";
         ctu_panic("%s (rc=%s)", ers, qv_strerr(rc));
@@ -289,13 +289,13 @@ main(
     int npus;
     if (my_numa_rank == 0) {
         /* I am the process lead */
-        rc = qv_scope_hw_obj_count(
+        rc = qv_hw_obj_count(
             numa_scope,
             QV_HW_OBJ_PU,
             &npus
         );
         if (rc != QV_SUCCESS) {
-            ers = "qv_scope_hw_obj_count() failed";
+            ers = "qv_hw_obj_count() failed";
             ctu_panic("%s (rc=%s)", ers, qv_strerr(rc));
         }
         printf("=> [%d] NUMA leader: Launching OMP region\n", wrank);
@@ -303,19 +303,19 @@ main(
     }
 
     /* Everybody else waits... */
-    rc = qv_scope_barrier(numa_scope);
+    rc = qv_barrier(numa_scope);
     if (rc != QV_SUCCESS) {
         ers = "qv_context_barrier() failed";
         ctu_panic("%s (rc=%s)", ers, qv_strerr(rc));
     }
 
-    rc = qv_scope_bind_pop(numa_scope);
+    rc = qv_bind_pop(numa_scope);
     if (rc != QV_SUCCESS) {
         ers = "qv_bind_pop() failed";
         ctu_panic("%s (rc=%s)", ers, qv_strerr(rc));
     }
 
-    rc = qv_scope_bind_string(base_scope, QV_BIND_STRING_LOGICAL, &binds);
+    rc = qv_bind_string(base_scope, QV_BIND_STRING_LOGICAL, &binds);
     if (rc != QV_SUCCESS) {
         ers = "qv_bind_get_list_as_string() failed";
         ctu_panic("%s (rc=%s)", ers, qv_strerr(rc));
@@ -324,7 +324,7 @@ main(
     free(binds);
 
     /* Keep printouts separate for each phase */
-    rc = qv_scope_barrier(base_scope);
+    rc = qv_barrier(base_scope);
     if (rc != QV_SUCCESS) {
       ers = "qv_context_barrier() failed";
       ctu_panic("%s (rc=%s)", ers, qv_strerr(rc));
@@ -343,10 +343,10 @@ main(
 
     /* Get the number of GPUs so that we can
        specify the color/groupid of split_at */
-    rc = qv_scope_hw_obj_count(base_scope,
+    rc = qv_hw_obj_count(base_scope,
             QV_HW_OBJ_GPU, &ngpus);
     if (rc != QV_SUCCESS) {
-      ers = "qv_scope_hw_obj_count() failed";
+      ers = "qv_hw_obj_count() failed";
       ctu_panic("%s (rc=%s)", ers, qv_strerr(rc));
     }
 
@@ -356,45 +356,45 @@ main(
     }
 
     /* Split at GPUs */
-    rc = qv_scope_split_at(
+    rc = qv_split_at(
         base_scope,
         QV_HW_OBJ_GPU,
         wrank % ngpus, // color or group id
         &gpu_scope
     );
     if (rc != QV_SUCCESS) {
-        ers = "qv_scope_split_at() failed";
+        ers = "qv_split_at() failed";
         ctu_panic("%s (rc=%s)", ers, qv_strerr(rc));
     }
 
     /* Allow selecting a leader per NUMA */
-    rc = qv_scope_group_rank(
+    rc = qv_group_rank(
         gpu_scope,
         &my_gpu_rank
     );
     if (rc != QV_SUCCESS) {
-        ers = "qv_scope_group_rank() failed";
+        ers = "qv_group_rank() failed";
         ctu_panic("%s (rc=%s)", ers, qv_strerr(rc));
     }
 
-    rc = qv_scope_bind_push(gpu_scope);
+    rc = qv_bind_push(gpu_scope);
     if (rc != QV_SUCCESS) {
         ers = "qv_bind_push() failed";
         ctu_panic("%s (rc=%s)", ers, qv_strerr(rc));
     }
 
     int my_ngpus;
-    rc = qv_scope_hw_obj_count(
+    rc = qv_hw_obj_count(
             gpu_scope,
             QV_HW_OBJ_GPU,
             &my_ngpus);
     if (rc != QV_SUCCESS) {
-        ers = "qv_scope_hw_obj_count() failed";
+        ers = "qv_hw_obj_count() failed";
         ctu_panic("%s (rc=%s)", ers, qv_strerr(rc));
     }
 
     /* Where did I end up? */
-    rc = qv_scope_bind_string(gpu_scope, QV_BIND_STRING_LOGICAL, &binds);
+    rc = qv_bind_string(gpu_scope, QV_BIND_STRING_LOGICAL, &binds);
     if (rc != QV_SUCCESS) {
         ers = "qv_bind_get_list_as_string() failed";
         ctu_panic("%s (rc=%s)", ers, qv_strerr(rc));
@@ -404,7 +404,7 @@ main(
     free(binds);
 
     for (int i=0; i<my_ngpus; i++) {
-      qv_scope_device_id(gpu_scope, QV_HW_OBJ_GPU,
+      qv_device_id(gpu_scope, QV_HW_OBJ_GPU,
               i, QV_DEVICE_ID_PCI_BUS_ID, &gpu);
       printf("   [%d] GPU %d PCI Bus ID = %s\n", wrank, i, gpu);
       free(gpu);
@@ -413,28 +413,28 @@ main(
     /***************************************
      * Clean up
      ***************************************/
-    rc = qv_scope_free(gpu_scope);
+    rc = qv_free(gpu_scope);
     if (rc != QV_SUCCESS) {
-        ers = "qv_scope_free() failed";
+        ers = "qv_free() failed";
         ctu_panic("%s (rc=%s)", ers, qv_strerr(rc));
     }
 
 done:
-    rc = qv_scope_free(numa_scope);
+    rc = qv_free(numa_scope);
     if (rc != QV_SUCCESS) {
-        ers = "qv_scope_free() failed";
+        ers = "qv_free() failed";
         ctu_panic("%s (rc=%s)", ers, qv_strerr(rc));
     }
 
-    rc = qv_scope_free(sub_scope);
+    rc = qv_free(sub_scope);
     if (rc != QV_SUCCESS) {
-        ers = "qv_scope_free() failed";
+        ers = "qv_free() failed";
         ctu_panic("%s (rc=%s)", ers, qv_strerr(rc));
     }
 
-    rc = qv_scope_free(base_scope);
+    rc = qv_free(base_scope);
     if (rc != QV_SUCCESS) {
-        ers = "qv_scope_free() failed";
+        ers = "qv_free() failed";
         ctu_panic("%s (rc=%s)", ers, qv_strerr(rc));
     }
 

--- a/tests/test-mpi-scope-create.c
+++ b/tests/test-mpi-scope-create.c
@@ -16,22 +16,22 @@ scope_report(
     char const *ers = NULL;
     // Get my base_scope's size and my rank.
     int base_scope_size;
-    int rc = qv_scope_group_size(
+    int rc = qv_group_size(
         base_scope,
         &base_scope_size
     );
     if (rc != QV_SUCCESS) {
-        ers = "qv_scope_group_size() failed";
+        ers = "qv_group_size() failed";
         ctu_panic("%s (rc=%s)", ers, qv_strerr(rc));
     }
 
     int base_scope_rank;
-    rc = qv_scope_group_rank(
+    rc = qv_group_rank(
         base_scope,
         &base_scope_rank
     );
     if (rc != QV_SUCCESS) {
-        ers = "qv_scope_group_rank() failed";
+        ers = "qv_group_rank() failed";
         ctu_panic("%s (rc=%s)", ers, qv_strerr(rc));
     }
 
@@ -44,9 +44,9 @@ scope_report(
         else {
             ctu_emit(sub_scope, CTU_SCOPE_KIND_MPI, "");
         }
-        rc = qv_scope_barrier(base_scope);
+        rc = qv_barrier(base_scope);
         if (rc != QV_SUCCESS) {
-            ers = "qv_scope_barrier() failed";
+            ers = "qv_barrier() failed";
             ctu_panic("%s (rc=%s)", ers, qv_strerr(rc));
         }
     }
@@ -71,7 +71,7 @@ test_create_scope(
     }
 
     qv_scope_t *core_scope;
-    int rc = qv_scope_create(
+    int rc = qv_create_scope(
         scope_to_test,
         QV_SCOPE_FLAG_NONE,
         QV_HW_OBJ_CORE,
@@ -79,7 +79,7 @@ test_create_scope(
         &core_scope
     );
     if (rc != QV_SUCCESS) {
-        ers = "qv_scope_create() failed";
+        ers = "qv_create_scope() failed";
         ctu_panic("%s (rc=%s)", ers, qv_strerr(rc));
     }
 
@@ -87,9 +87,9 @@ test_create_scope(
     free(scope_name);
 
     if (free_scope) {
-        rc = qv_scope_free(core_scope);
+        rc = qv_free(core_scope);
         if (rc != QV_SUCCESS) {
-            ers = "qv_scope_free() failed";
+            ers = "qv_free() failed";
             ctu_panic("%s (rc=%s)", ers, qv_strerr(rc));
         }
         core_scope = NULL;
@@ -112,34 +112,34 @@ main(
     }
 
     qv_scope_t *base_scope;
-    rc = qv_mpi_scope_get(
+    rc = qv_mpi_scope(
         comm,
         QV_SCOPE_USER,
         QV_SCOPE_FLAG_NONE,
         &base_scope
     );
     if (rc != QV_SUCCESS) {
-        ers = "qv_mpi_scope_get() failed";
+        ers = "qv_mpi_scope() failed";
         ctu_panic("%s (rc=%s)", ers, qv_strerr(rc));
     }
 
     int base_scope_size;
-    rc = qv_scope_group_size(
+    rc = qv_group_size(
         base_scope,
         &base_scope_size
     );
     if (rc != QV_SUCCESS) {
-        ers = "qv_scope_group_size() failed";
+        ers = "qv_group_size() failed";
         ctu_panic("%s (rc=%s)", ers, qv_strerr(rc));
     }
 
     int base_scope_rank;
-    rc = qv_scope_group_rank(
+    rc = qv_group_rank(
         base_scope,
         &base_scope_rank
     );
     if (rc != QV_SUCCESS) {
-        ers = "qv_scope_group_rank() failed";
+        ers = "qv_group_rank() failed";
         ctu_panic("%s (rc=%s)", ers, qv_strerr(rc));
     }
 
@@ -151,14 +151,14 @@ main(
     );
     // Split the base scope evenly across workers.
     qv_scope_t *sub_scope;
-    rc = qv_scope_split(
+    rc = qv_split(
         base_scope,
         base_scope_size,
         base_scope_rank,
         &sub_scope
     );
     if (rc != QV_SUCCESS) {
-        ers = "qv_scope_split() failed";
+        ers = "qv_split() failed";
         ctu_panic("%s (rc=%s)", ers, qv_strerr(rc));
     }
     scope_report(base_scope, sub_scope, "sub_scope");
@@ -187,22 +187,22 @@ main(
     core_scopes[3] = test_create_scope(base_scope, sub_scope, ncore1, true);
 
     for (int i = 0; i < n_core_scopes; ++i) {
-        rc = qv_scope_free(core_scopes[i]);
+        rc = qv_free(core_scopes[i]);
         if (rc != QV_SUCCESS) {
-            ers = "qv_scope_free() failed";
+            ers = "qv_free() failed";
             ctu_panic("%s (rc=%s)", ers, qv_strerr(rc));
         }
     }
 
-    rc = qv_scope_free(sub_scope);
+    rc = qv_free(sub_scope);
     if (rc != QV_SUCCESS) {
-        ers = "qv_scope_free() failed";
+        ers = "qv_free() failed";
         ctu_panic("%s (rc=%s)", ers, qv_strerr(rc));
     }
 
-    rc = qv_scope_free(base_scope);
+    rc = qv_free(base_scope);
     if (rc != QV_SUCCESS) {
-        ers = "qv_scope_free() failed";
+        ers = "qv_free() failed";
         ctu_panic("%s (rc=%s)", ers, qv_strerr(rc));
     }
 

--- a/tests/test-mpi-scopes.c
+++ b/tests/test-mpi-scopes.c
@@ -38,14 +38,14 @@ main(
     }
     // Self scope test
     qv_scope_t *self_scope;
-    rc = qv_mpi_scope_get(
+    rc = qv_mpi_scope(
         comm,
         QV_SCOPE_PROCESS,
         QV_SCOPE_FLAG_NONE,
         &self_scope
     );
     if (rc != QV_SUCCESS) {
-        ers = "qv_mpi_scope_get(QV_SCOPE_PROCESS) failed";
+        ers = "qv_mpi_scope(QV_SCOPE_PROCESS) failed";
         ctu_panic("%s (rc=%s)", ers, qv_strerr(rc));
     }
 
@@ -66,42 +66,42 @@ main(
         }
     }
 
-    rc = qv_scope_free(self_scope);
+    rc = qv_free(self_scope);
     if (rc != QV_SUCCESS) {
-        ers = "qv_scope_free() failed";
+        ers = "qv_free() failed";
         ctu_panic("%s (rc=%s)", ers, qv_strerr(rc));
     }
     // Base scope test
     qv_scope_t *base_scope;
-    rc = qv_mpi_scope_get(
+    rc = qv_mpi_scope(
         comm,
         QV_SCOPE_JOB,
         QV_SCOPE_FLAG_NONE,
         &base_scope
     );
     if (rc != QV_SUCCESS) {
-        ers = "qv_mpi_scope_get() failed";
+        ers = "qv_mpi_scope() failed";
         ctu_panic("%s (rc=%s)", ers, qv_strerr(rc));
     }
 
     // Get my base_scope's size and my rank.
     int base_scope_size;
-    rc = qv_scope_group_size(
+    rc = qv_group_size(
         base_scope,
         &base_scope_size
     );
     if (rc != QV_SUCCESS) {
-        ers = "qv_scope_group_size() failed";
+        ers = "qv_group_size() failed";
         ctu_panic("%s (rc=%s)", ers, qv_strerr(rc));
     }
 
     int base_scope_rank;
-    rc = qv_scope_group_rank(
+    rc = qv_group_rank(
         base_scope,
         &base_scope_rank
     );
     if (rc != QV_SUCCESS) {
-        ers = "qv_scope_group_rank() failed";
+        ers = "qv_group_rank() failed";
         ctu_panic("%s (rc=%s)", ers, qv_strerr(rc));
     }
 
@@ -114,32 +114,32 @@ main(
         else {
             ctu_emit(base_scope, CTU_SCOPE_KIND_MPI, "");
         }
-        rc = qv_scope_barrier(base_scope);
+        rc = qv_barrier(base_scope);
         if (rc != QV_SUCCESS) {
-            ers = "qv_scope_barrier() failed";
+            ers = "qv_barrier() failed";
             ctu_panic("%s (rc=%s)", ers, qv_strerr(rc));
         }
     }
 
     int base_scope_sgsize;
-    rc = qv_scope_group_size(
+    rc = qv_group_size(
         base_scope,
         &base_scope_sgsize
     );
     if (rc != QV_SUCCESS) {
-        ers = "qv_scope_group_size() failed";
+        ers = "qv_group_size() failed";
         ctu_panic("%s (rc=%s)", ers, qv_strerr(rc));
     }
 
     qv_scope_t *sub_scope;
-    rc = qv_scope_split(
+    rc = qv_split(
         base_scope,
         npieces,
         QV_SCOPE_SPLIT_PACKED,
         &sub_scope
     );
     if (rc != QV_SUCCESS) {
-        ers = "qv_scope_split() failed";
+        ers = "qv_split() failed";
         ctu_panic("%s (rc=%s)", ers, qv_strerr(rc));
     }
 
@@ -152,16 +152,16 @@ main(
         else {
             ctu_emit(sub_scope, CTU_SCOPE_KIND_MPI, "");
         }
-        rc = qv_scope_barrier(base_scope);
+        rc = qv_barrier(base_scope);
         if (rc != QV_SUCCESS) {
-            ers = "qv_scope_barrier() failed";
+            ers = "qv_barrier() failed";
             ctu_panic("%s (rc=%s)", ers, qv_strerr(rc));
         }
     }
 
     if (base_scope_rank == 0) {
         qv_scope_t *create_scope;
-        rc = qv_scope_create(
+        rc = qv_create_scope(
             sub_scope,
             QV_SCOPE_FLAG_NONE,
             QV_HW_OBJ_CORE,
@@ -169,7 +169,7 @@ main(
             &create_scope
         );
         if (rc != QV_SUCCESS) {
-            ers = "qv_scope_create() failed";
+            ers = "qv_create_scope() failed";
             ctu_panic("%s (rc=%s)", ers, qv_strerr(rc));
         }
 
@@ -177,22 +177,22 @@ main(
             create_scope, CTU_SCOPE_KIND_MPI, " create_scope"
         );
 
-        rc = qv_scope_free(create_scope);
+        rc = qv_free(create_scope);
         if (rc != QV_SUCCESS) {
-            ers = "qv_scope_free() failed";
+            ers = "qv_free() failed";
             ctu_panic("%s (rc=%s)", ers, qv_strerr(rc));
         }
     }
 
     qv_scope_t *sub_sub_scope;
-    rc = qv_scope_split(
+    rc = qv_split(
         sub_scope,
         npieces,
         QV_SCOPE_SPLIT_SPREAD,
         &sub_sub_scope
     );
     if (rc != QV_SUCCESS) {
-        ers = "qv_scope_split() failed";
+        ers = "qv_split() failed";
         ctu_panic("%s (rc=%s)", ers, qv_strerr(rc));
     }
 
@@ -205,28 +205,28 @@ main(
         else {
             ctu_emit(sub_sub_scope, CTU_SCOPE_KIND_MPI, "");
         }
-        rc = qv_scope_barrier(base_scope);
+        rc = qv_barrier(base_scope);
         if (rc != QV_SUCCESS) {
-            ers = "qv_scope_barrier() failed";
+            ers = "qv_barrier() failed";
             ctu_panic("%s (rc=%s)", ers, qv_strerr(rc));
         }
     }
 
-    rc = qv_scope_free(base_scope);
+    rc = qv_free(base_scope);
     if (rc != QV_SUCCESS) {
-        ers = "qv_scope_free() failed";
+        ers = "qv_free() failed";
         ctu_panic("%s (rc=%s)", ers, qv_strerr(rc));
     }
 
-    rc = qv_scope_free(sub_scope);
+    rc = qv_free(sub_scope);
     if (rc != QV_SUCCESS) {
-        ers = "qv_scope_free() failed";
+        ers = "qv_free() failed";
         ctu_panic("%s (rc=%s)", ers, qv_strerr(rc));
     }
 
-    rc = qv_scope_free(sub_sub_scope);
+    rc = qv_free(sub_sub_scope);
     if (rc != QV_SUCCESS) {
-        ers = "qv_scope_free() failed";
+        ers = "qv_free() failed";
         ctu_panic("%s (rc=%s)", ers, qv_strerr(rc));
     }
 

--- a/tests/test-mpi-threads.c
+++ b/tests/test-mpi-threads.c
@@ -49,67 +49,67 @@ main(
     ////////////////////////////////////////////////////////////////////////////
     // Get the base scope: RM-given resources.
     qv_scope_t *base_scope;
-    rc = qv_mpi_scope_get(
+    rc = qv_mpi_scope(
         comm, QV_SCOPE_USER, QV_SCOPE_FLAG_NONE, &base_scope
     );
     if (rc != QV_SUCCESS) {
-        ers = "qv_mpi_scope_get() failed";
+        ers = "qv_mpi_scope() failed";
         ctu_panic("%s (rc=%s)", ers, qv_strerr(rc));
     }
 
     int nnumas;
-    rc = qv_scope_hw_obj_count(base_scope, QV_HW_OBJ_NUMANODE, &nnumas);
+    rc = qv_hw_obj_count(base_scope, QV_HW_OBJ_NUMANODE, &nnumas);
     if (rc != QV_SUCCESS) {
-        ers = "qv_scope_hw_obj_count() failed";
+        ers = "qv_hw_obj_count() failed";
         ctu_panic("%s (rc=%s)", ers, qv_strerr(rc));
     }
     // Split at NUMA domains.
     qv_scope_t *numa_scope;
-    rc = qv_scope_split_at(
+    rc = qv_split_at(
         base_scope, QV_HW_OBJ_NUMANODE,
         wrank % nnumas, &numa_scope
     );
     if (rc != QV_SUCCESS) {
-        ers = "qv_scope_split_at() failed";
+        ers = "qv_split_at() failed";
         ctu_panic("%s (rc=%s)", ers, qv_strerr(rc));
     }
     // When there's more tasks than NUMAs,
     // make sure each task has exclusive resources.
     int lrank;
-    rc = qv_scope_group_rank(numa_scope, &lrank);
+    rc = qv_group_rank(numa_scope, &lrank);
     if (rc != QV_SUCCESS) {
-        ers = "qv_scope_group_rank() failed";
+        ers = "qv_group_rank() failed";
         ctu_panic("%s (rc=%s)", ers, qv_strerr(rc));
     }
 
     int ntasks_per_numa;
-    rc = qv_scope_group_size(numa_scope, &ntasks_per_numa);
+    rc = qv_group_size(numa_scope, &ntasks_per_numa);
     if (rc != QV_SUCCESS) {
-        ers = "qv_scope_group_size() failed";
+        ers = "qv_group_size() failed";
         ctu_panic("%s (rc=%s)", ers, qv_strerr(rc));
     }
 
     qv_scope_t *subnuma;
-    rc = qv_scope_split(
+    rc = qv_split(
         numa_scope, ntasks_per_numa,
         lrank % ntasks_per_numa, &subnuma
     );
     if (rc != QV_SUCCESS) {
-        ers = "qv_scope_split() failed";
+        ers = "qv_split() failed";
         ctu_panic("%s (rc=%s)", ers, qv_strerr(rc));
     }
     // Get the number of cores and pus per NUMA part.
     int ncores;
-    rc = qv_scope_hw_obj_count(subnuma, QV_HW_OBJ_CORE, &ncores);
+    rc = qv_hw_obj_count(subnuma, QV_HW_OBJ_CORE, &ncores);
     if (rc != QV_SUCCESS) {
-        ers = "qv_scope_hw_obj_count() failed";
+        ers = "qv_hw_obj_count() failed";
         ctu_panic("%s (rc=%s)", ers, qv_strerr(rc));
     }
 
     int npus;
-    rc = qv_scope_hw_obj_count(subnuma, QV_HW_OBJ_PU, &npus);
+    rc = qv_hw_obj_count(subnuma, QV_HW_OBJ_PU, &npus);
     if (rc != QV_SUCCESS) {
-        ers = "qv_scope_hw_obj_count() failed";
+        ers = "qv_hw_obj_count() failed";
         ctu_panic("%s (rc=%s)", ers, qv_strerr(rc));
     }
     ////////////////////////////////////////////////////////////////////////////
@@ -122,11 +122,11 @@ main(
     );
     int *thread_coloring = NULL; // Default thread assignment.
     qv_scope_t **th_scopes;
-    rc = qv_thread_scope_split_at(
+    rc = qv_thread_split_at(
         subnuma, QV_HW_OBJ_CORE, thread_coloring, nthreads, &th_scopes
     );
     if (rc != QV_SUCCESS) {
-        ers = "qv_thread_scope_split_at() failed";
+        ers = "qv_thread_split_at() failed";
         ctu_panic("%s (rc=%s)", ers, qv_strerr(rc));
     }
 
@@ -135,13 +135,13 @@ main(
     {
         const int tid = omp_get_thread_num();
         // Each thread works with its new hardware affinity.
-        qv_scope_bind_push(th_scopes[tid]);
+        qv_bind_push(th_scopes[tid]);
         thread_work(th_scopes[tid]);
     }
     // When we are done with the scope, clean up.
-    rc = qv_thread_scopes_free(nthreads, th_scopes);
+    rc = qv_thread_free(nthreads, th_scopes);
     if (rc != QV_SUCCESS) {
-        ers = "qv_thread_scopes_free() failed";
+        ers = "qv_thread_free() failed";
         ctu_panic("%s (rc=%s)", ers, qv_strerr(rc));
     }
     ctu_pemit(
@@ -159,11 +159,11 @@ main(
         "# Starting Pthread test (nthreads/process=%d)\n", nthreads
     );
     thread_coloring = QV_THREAD_SCOPE_SPLIT_PACKED,
-    rc = qv_thread_scope_split_at(
+    rc = qv_thread_split_at(
         subnuma, QV_HW_OBJ_PU, thread_coloring, nthreads, &th_scopes
     );
     if (rc != QV_SUCCESS) {
-        ers = "qv_thread_scope_split_at() failed";
+        ers = "qv_thread_split_at() failed";
         ctu_panic("%s (rc=%s)", ers, qv_strerr(rc));
     }
 
@@ -192,15 +192,15 @@ main(
         "# Done!\n"
     );
     // When we are done with the scope, clean up.
-    rc = qv_thread_scopes_free(nthreads, th_scopes);
+    rc = qv_thread_free(nthreads, th_scopes);
     if (rc != QV_SUCCESS) {
-        ers = "qv_thread_scopes_free() failed";
+        ers = "qv_thread_free() failed";
         ctu_panic("%s (rc=%s)", ers, qv_strerr(rc));
     }
     // Clean up.
-    qv_scope_free(subnuma);
-    qv_scope_free(numa_scope);
-    qv_scope_free(base_scope);
+    qv_free(subnuma);
+    qv_free(numa_scope);
+    qv_free(base_scope);
 
     MPI_Finalize();
 

--- a/tests/test-omp.c
+++ b/tests/test-omp.c
@@ -18,9 +18,9 @@ scopei_free(
     scopei *sinfo
 ) {
     char *ers = NULL;
-    const int rc = qv_thread_scopes_free(sinfo->nthreads, sinfo->th_scopes);
+    const int rc = qv_thread_free(sinfo->nthreads, sinfo->th_scopes);
     if (rc != QV_SUCCESS) {
-        ers = "qv_thread_scopes_free() failed";
+        ers = "qv_thread_free() failed";
         ctu_panic("%s (rc=%s)", ers, qv_strerr(rc));
     }
 }
@@ -35,7 +35,7 @@ scopei_ep(
     char *ers = NULL;
 
     qv_scope_t *base_scope;
-    int rc = qv_process_scope_get(
+    int rc = qv_process_scope(
         QV_SCOPE_PROCESS, QV_SCOPE_FLAG_NONE, &base_scope
     );
     if (rc != QV_SUCCESS) {
@@ -43,25 +43,25 @@ scopei_ep(
         ctu_panic("%s (rc=%s)", ers, qv_strerr(rc));
     }
     // Use the number of cores to determine how many thread scopes to create.
-    rc = qv_scope_hw_obj_count(base_scope, QV_HW_OBJ_CORE, &sinfo->nthreads);
+    rc = qv_hw_obj_count(base_scope, QV_HW_OBJ_CORE, &sinfo->nthreads);
     if (rc != QV_SUCCESS) {
-        ers = "qv_scope_hw_obj_count() failed";
+        ers = "qv_hw_obj_count() failed";
         ctu_panic("%s (rc=%s)", ers, qv_strerr(rc));
     }
 
     int *thread_coloring = QV_THREAD_SCOPE_SPLIT_CLOSE;
-    rc = qv_thread_scope_split_at(
+    rc = qv_thread_split_at(
         base_scope, QV_HW_OBJ_CORE, thread_coloring,
         sinfo->nthreads, &sinfo->th_scopes
     );
     if (rc != QV_SUCCESS) {
-        ers = "qv_thread_scope_split_at() failed";
+        ers = "qv_thread_split_at() failed";
         ctu_panic("%s (rc=%s)", ers, qv_strerr(rc));
     }
 
-    rc = qv_scope_free(base_scope);
+    rc = qv_free(base_scope);
     if (rc != QV_SUCCESS) {
-        ers = "qv_scope_free() failed";
+        ers = "qv_free() failed";
         ctu_panic("%s (rc=%s)", ers, qv_strerr(rc));
     }
 }
@@ -71,9 +71,9 @@ scopei_ep_push(
     scopei *sinfo,
     int rank
 ) {
-    const int rc = qv_scope_bind_push(sinfo->th_scopes[rank]);
+    const int rc = qv_bind_push(sinfo->th_scopes[rank]);
     if (rc != QV_SUCCESS) {
-        char *ers = "qv_scope_bind_push() failed";
+        char *ers = "qv_bind_push() failed";
         ctu_panic("%s (rc=%s)", ers, qv_strerr(rc));
     }
 }
@@ -83,9 +83,9 @@ scopei_ep_pop(
     scopei *sinfo,
     int rank
 ) {
-    const int rc = qv_scope_bind_pop(sinfo->th_scopes[rank]);
+    const int rc = qv_bind_pop(sinfo->th_scopes[rank]);
     if (rc != QV_SUCCESS) {
-        char *ers = "qv_scope_bind_pop() failed";
+        char *ers = "qv_bind_pop() failed";
         ctu_panic("%s (rc=%s)", ers, qv_strerr(rc));
     }
 }
@@ -99,7 +99,7 @@ emit_iter_info(
     char const *ers = NULL;
 
     char *binds;
-    const int rc = qv_scope_bind_string(
+    const int rc = qv_bind_string(
         sinfo->th_scopes[rank], QV_BIND_STRING_LOGICAL, &binds
     );
     if (rc != QV_SUCCESS) {

--- a/tests/test-process-fortapi.f90
+++ b/tests/test-process-fortapi.f90
@@ -16,46 +16,46 @@ program process_fortapi
     character(len=:),allocatable :: dev_pci(:)
     character, pointer, dimension(:) :: strerr
 
-    call qv_process_scope_get( &
+    call qv_process_scope( &
         QV_SCOPE_USER, QV_SCOPE_FLAG_NONE, scope_user, info &
     )
     if (info .ne. QV_SUCCESS) then
         error stop
     end if
 
-    call qv_scope_group_size(scope_user, sgsize, info)
+    call qv_group_size(scope_user, sgsize, info)
     if (info .ne. QV_SUCCESS) then
         error stop
     end if
     print *, 'sgsize', sgsize
 
-    call qv_scope_group_rank(scope_user, sgrank, info)
+    call qv_group_rank(scope_user, sgrank, info)
     if (info .ne. QV_SUCCESS) then
         error stop
     end if
     print *, 'sgrank', sgrank
 
-    call qv_scope_hw_obj_count(scope_user, QV_HW_OBJ_CORE, n_cores, info)
+    call qv_hw_obj_count(scope_user, QV_HW_OBJ_CORE, n_cores, info)
     if (info .ne. QV_SUCCESS) then
         error stop
     end if
     print *, 'ncores', n_cores
 
-    call qv_scope_bind_string(scope_user, QV_BIND_STRING_LOGICAL, bstr, info)
+    call qv_bind_string(scope_user, QV_BIND_STRING_LOGICAL, bstr, info)
     if (info .ne. QV_SUCCESS) then
         error stop
     end if
     print *, 'bstr ', bstr
     deallocate(bstr)
 
-    call qv_scope_hw_obj_count(scope_user, QV_HW_OBJ_GPU, n_gpu, info)
+    call qv_hw_obj_count(scope_user, QV_HW_OBJ_GPU, n_gpu, info)
     if (info .ne. QV_SUCCESS) then
         error stop
     end if
     print *, 'ngpu', n_gpu
 
     do n = 0, n_gpu - 1
-        call qv_scope_device_id( &
+        call qv_device_id( &
             scope_user, QV_HW_OBJ_GPU, n, &
             QV_DEVICE_ID_PCI_BUS_ID, dev_pci, info &
         )
@@ -73,7 +73,7 @@ program process_fortapi
     strerr => qv_strerr(QV_ERR_OOR)
     print *, 'err oor is ', strerr
 
-    call qv_scope_free(scope_user, info)
+    call qv_free(scope_user, info)
     if (info .ne. QV_SUCCESS) then
         error stop
     end if

--- a/tests/test-process-hardware.c
+++ b/tests/test-process-hardware.c
@@ -25,7 +25,7 @@ main(void)
         char const *ers = NULL;
 
         qv_scope_t *base_scope;
-        int rc = qv_process_scope_get(
+        int rc = qv_process_scope(
             QV_SCOPE_USER,
             setup_tab[i].flags,
             &base_scope
@@ -50,9 +50,9 @@ main(void)
         );
         ctu_emit(base_scope, CTU_SCOPE_KIND_PROCESS, "\n");
 
-        rc = qv_scope_free(base_scope);
+        rc = qv_free(base_scope);
         if (rc != QV_SUCCESS) {
-            ers = "qv_scope_free() failed";
+            ers = "qv_free() failed";
             ctu_panic("%s (rc=%s)", ers, qv_strerr(rc));
         }
     }

--- a/tests/test-process-scopes.c
+++ b/tests/test-process-scopes.c
@@ -10,7 +10,7 @@ main(void)
     int rc = QV_SUCCESS;
 
     qv_scope_t *self_scope = NULL;
-    rc = qv_process_scope_get(
+    rc = qv_process_scope(
         QV_SCOPE_PROCESS, QV_SCOPE_FLAG_NONE, &self_scope
     );
     if (rc != QV_SUCCESS) {
@@ -22,14 +22,14 @@ main(void)
         self_scope, CTU_SCOPE_KIND_PROCESS, "     self_scope"
     );
 
-    rc = qv_scope_free(self_scope);
+    rc = qv_free(self_scope);
     if (rc != QV_SUCCESS) {
-        ers = "qv_scope_free() failed";
+        ers = "qv_free() failed";
         ctu_panic("%s (rc=%s)", ers, qv_strerr(rc));
     }
 
     qv_scope_t *base_scope;
-    rc = qv_process_scope_get(
+    rc = qv_process_scope(
         QV_SCOPE_USER, QV_SCOPE_FLAG_NONE, &base_scope
     );
     if (rc != QV_SUCCESS) {
@@ -42,9 +42,9 @@ main(void)
     );
 
     int sgsize;
-    rc = qv_scope_group_size(base_scope, &sgsize);
+    rc = qv_group_size(base_scope, &sgsize);
     if (rc != QV_SUCCESS) {
-        ers = "qv_scope_group_size() failed";
+        ers = "qv_group_size() failed";
         ctu_panic("%s (rc=%s)", ers, qv_strerr(rc));
     }
     if (sgsize != 1) {
@@ -61,21 +61,21 @@ main(void)
     // Provided color in range, so we will get the LHS of the split.
     // That is, with 2 pieces, the in-range coloring values are 0 and 1.
     qv_scope_t *sub_scope_left;
-    rc = qv_scope_split(
+    rc = qv_split(
         base_scope, npieces, 0, &sub_scope_left
     );
     if (rc != QV_SUCCESS) {
-        ers = "qv_scope_split() failed";
+        ers = "qv_split() failed";
         ctu_panic("%s (rc=%s)", ers, qv_strerr(rc));
     }
     // Provided color in range, so we will get the RHS of the split.
     // That is, with 2 pieces, the in-range coloring values are 0 and 1.
     qv_scope_t *sub_scope_right;
-    rc = qv_scope_split(
+    rc = qv_split(
         base_scope, npieces, 1, &sub_scope_right
     );
     if (rc != QV_SUCCESS) {
-        ers = "qv_scope_split() failed";
+        ers = "qv_split() failed";
         ctu_panic("%s (rc=%s)", ers, qv_strerr(rc));
     }
 
@@ -93,21 +93,21 @@ main(void)
         sub_scope_right, CTU_SCOPE_KIND_PROCESS, "sub_scope_right"
     );
 
-    rc = qv_scope_free(base_scope);
+    rc = qv_free(base_scope);
     if (rc != QV_SUCCESS) {
-        ers = "qv_scope_free() failed";
+        ers = "qv_free() failed";
         ctu_panic("%s (rc=%s)", ers, qv_strerr(rc));
     }
 
-    rc = qv_scope_free(sub_scope_left);
+    rc = qv_free(sub_scope_left);
     if (rc != QV_SUCCESS) {
-        ers = "qv_scope_free() failed";
+        ers = "qv_free() failed";
         ctu_panic("%s (rc=%s)", ers, qv_strerr(rc));
     }
 
-    rc = qv_scope_free(sub_scope_right);
+    rc = qv_free(sub_scope_right);
     if (rc != QV_SUCCESS) {
-        ers = "qv_scope_free() failed";
+        ers = "qv_free() failed";
         ctu_panic("%s (rc=%s)", ers, qv_strerr(rc));
     }
 

--- a/tests/test-progress-thread.c
+++ b/tests/test-progress-thread.c
@@ -18,7 +18,7 @@
  * Or
  * qv_scope_set_utility(context, input_scope);
  *
- * (2) Define qv_scope_create_hint for qv_scope_create.
+ * (2) Define qv_create_scope_hint for qv_create_scope.
  * We may need:
  * // Get PUs from the tail of the list
  * QV_SCOPE_CREATE_LAST
@@ -77,24 +77,24 @@ int main(int argc, char *argv[])
     }
 
     qv_scope_t *user_scope;
-    rc = qv_mpi_scope_get(
+    rc = qv_mpi_scope(
         comm, QV_SCOPE_USER, QV_SCOPE_FLAG_NONE, &user_scope
     );
     if (rc != QV_SUCCESS) {
-        ers = "qv_mpi_scope_get() failed";
+        ers = "qv_mpi_scope() failed";
         ctu_panic("%s (rc=%s)", ers, qv_strerr(rc));
     }
 
     /* Split user scope evenly across tasks */
     qv_scope_t *task_scope;
-    rc = qv_scope_split(user_scope, wsize, wrank, &task_scope);
+    rc = qv_split(user_scope, wsize, wrank, &task_scope);
     if (rc != QV_SUCCESS) {
-        ers = "qv_scope_split() failed";
+        ers = "qv_split() failed";
         ctu_panic("%s (rc=%s)", ers, qv_strerr(rc));
     }
 
     /* Push into my task scope */
-    rc = qv_scope_bind_push(task_scope);
+    rc = qv_bind_push(task_scope);
     if (rc != QV_SUCCESS) {
         ers = "qv_bind_push() failed";
         ctu_panic("%s (rc=%s)", ers, qv_strerr(rc));
@@ -102,7 +102,7 @@ int main(int argc, char *argv[])
 
     /* Where did I end up? */
     char *binds;
-    rc = qv_scope_bind_string(task_scope, QV_BIND_STRING_LOGICAL, &binds);
+    rc = qv_bind_string(task_scope, QV_BIND_STRING_LOGICAL, &binds);
     if (rc != QV_SUCCESS) {
         ers = "qv_bind_get_list_as_string() failed";
         ctu_panic("%s (rc=%s)", ers, qv_strerr(rc));
@@ -116,7 +116,7 @@ int main(int argc, char *argv[])
      * how could we set aside cores/pus for the progress threads
      * and not use those resources for the application's work?
      * Currently, we could get around this by implementing
-     * hints in qv_scope_create as detailed in this file.
+     * hints in qv_create_scope as detailed in this file.
      * Another way of doing this is by allowing the creation of
      * intrinsic *named* scopes that can be set by the application
      * and used by the external library.
@@ -133,74 +133,74 @@ int main(int argc, char *argv[])
      */
 
     int ncores;
-    rc = qv_scope_hw_obj_count(task_scope, QV_HW_OBJ_CORE, &ncores);
+    rc = qv_hw_obj_count(task_scope, QV_HW_OBJ_CORE, &ncores);
     if (rc != QV_SUCCESS) {
-        ers = "qv_scope_hw_obj_count() failed";
+        ers = "qv_hw_obj_count() failed";
         ctu_panic("%s (rc=%s)", ers, qv_strerr(rc));
     }
 
     qv_scope_t *wk_scope;
-    rc = qv_scope_create(task_scope, QV_SCOPE_FLAG_NONE, QV_HW_OBJ_CORE, ncores-1, &wk_scope);
+    rc = qv_create_scope(task_scope, QV_SCOPE_FLAG_NONE, QV_HW_OBJ_CORE, ncores-1, &wk_scope);
     if (rc != QV_SUCCESS) {
-        ers = "qv_scope_create() failed";
+        ers = "qv_create_scope() failed";
         ctu_panic("%s (rc=%s)", ers, qv_strerr(rc));
     }
 
     qv_scope_t *ut_scope;
-    rc = qv_scope_create(task_scope, QV_SCOPE_FLAG_NONE, QV_HW_OBJ_CORE, 1, &ut_scope);
+    rc = qv_create_scope(task_scope, QV_SCOPE_FLAG_NONE, QV_HW_OBJ_CORE, 1, &ut_scope);
     if (rc != QV_SUCCESS) {
-        ers = "qv_scope_create() failed";
+        ers = "qv_create_scope() failed";
         ctu_panic("%s (rc=%s)", ers, qv_strerr(rc));
     }
 
     /* Test work scope */
-    rc = qv_scope_bind_push(wk_scope);
+    rc = qv_bind_push(wk_scope);
     if (rc != QV_SUCCESS) {
         ers = "qv_bind_push() failed";
         ctu_panic("%s (rc=%s)", ers, qv_strerr(rc));
     }
-    rc = qv_scope_bind_string(wk_scope, QV_BIND_STRING_LOGICAL, &binds);
+    rc = qv_bind_string(wk_scope, QV_BIND_STRING_LOGICAL, &binds);
     if (rc != QV_SUCCESS) {
         ers = "qv_bind_get_list_as_string() failed";
         ctu_panic("%s (rc=%s)", ers, qv_strerr(rc));
     }
     printf("[%d] Work scope: running on %s\n", wrank, binds);
     free(binds);
-    rc = qv_scope_bind_pop(wk_scope);
+    rc = qv_bind_pop(wk_scope);
     if (rc != QV_SUCCESS) {
         ers = "qv_bind_pop() failed";
         ctu_panic("%s (rc=%s)", ers, qv_strerr(rc));
     }
 
     /* Test utility scope */
-    rc = qv_scope_bind_push(ut_scope);
+    rc = qv_bind_push(ut_scope);
     if (rc != QV_SUCCESS) {
         ers = "qv_bind_push() failed";
         ctu_panic("%s (rc=%s)", ers, qv_strerr(rc));
     }
-    rc = qv_scope_bind_string(ut_scope, QV_BIND_STRING_LOGICAL, &binds);
+    rc = qv_bind_string(ut_scope, QV_BIND_STRING_LOGICAL, &binds);
     if (rc != QV_SUCCESS) {
         ers = "qv_bind_get_list_as_string() failed";
         ctu_panic("%s (rc=%s)", ers, qv_strerr(rc));
     }
     printf("[%d] Utility scope: running on %s\n", wrank, binds);
     free(binds);
-    rc = qv_scope_bind_pop(ut_scope);
+    rc = qv_bind_pop(ut_scope);
     if (rc != QV_SUCCESS) {
         ers = "qv_bind_pop() failed";
         ctu_panic("%s (rc=%s)", ers, qv_strerr(rc));
     }
 
     /* Clean up for now */
-    rc = qv_scope_free(ut_scope);
+    rc = qv_free(ut_scope);
     if (rc != QV_SUCCESS) {
-        ers = "qv_scope_free() failed";
+        ers = "qv_free() failed";
         ctu_panic("%s (rc=%s)", ers, qv_strerr(rc));
     }
 
-    rc = qv_scope_free(wk_scope);
+    rc = qv_free(wk_scope);
     if (rc != QV_SUCCESS) {
-        ers = "qv_scope_free() failed";
+        ers = "qv_free() failed";
         ctu_panic("%s (rc=%s)", ers, qv_strerr(rc));
     }
 
@@ -237,9 +237,9 @@ int main(int argc, char *argv[])
 
     /* Test we have PUs to use in the base scope */
     int npus;
-    rc = qv_scope_hw_obj_count(ctx2, base_scope, QV_HW_OBJ_PU, &npus);
+    rc = qv_hw_obj_count(ctx2, base_scope, QV_HW_OBJ_PU, &npus);
     if (rc != QV_SUCCESS) {
-        ers = "qv_scope_hw_obj_count() failed";
+        ers = "qv_hw_obj_count() failed";
         ctu_panic("%s (rc=%s)", ers, qv_strerr(rc));
     }
     printf("[%d] Base scope: npus=%d\n", wrank, npus);
@@ -247,9 +247,9 @@ int main(int argc, char *argv[])
     /* Create the progress thread scope */
     qv_scope_t *pt_scope = user_scope;
     if (npus > 0) {
-        rc = qv_scope_create(ctx2, base_scope, QV_HW_OBJ_PU, 1, 0, &pt_scope);
+        rc = qv_create_scope(ctx2, base_scope, QV_HW_OBJ_PU, 1, 0, &pt_scope);
         if (rc != QV_SUCCESS) {
-            ers = "qv_scope_create() failed";
+            ers = "qv_create_scope() failed";
             ctu_panic("%s (rc=%s)", ers, qv_strerr(rc));
         }
     }
@@ -271,15 +271,15 @@ int main(int argc, char *argv[])
 
 
     /* Clean up */
-    rc = qv_scope_free(ctx2, pt_scope);
+    rc = qv_free(ctx2, pt_scope);
     if (rc != QV_SUCCESS) {
-        ers = "qv_scope_free() failed";
+        ers = "qv_free() failed";
         ctu_panic("%s (rc=%s)", ers, qv_strerr(rc));
     }
 
-    rc = qv_scope_free(ctx2, base_scope);
+    rc = qv_free(ctx2, base_scope);
     if (rc != QV_SUCCESS) {
-        ers = "qv_scope_free() failed";
+        ers = "qv_free() failed";
         ctu_panic("%s (rc=%s)", ers, qv_strerr(rc));
     }
 
@@ -288,15 +288,15 @@ int main(int argc, char *argv[])
      * Back to the application
      ***************************************/
 
-    rc = qv_scope_free(ctx, task_scope);
+    rc = qv_free(ctx, task_scope);
     if (rc != QV_SUCCESS) {
-        ers = "qv_scope_free() failed";
+        ers = "qv_free() failed";
         ctu_panic("%s (rc=%s)", ers, qv_strerr(rc));
     }
 
-    rc = qv_scope_free(ctx, user_scope);
+    rc = qv_free(ctx, user_scope);
     if (rc != QV_SUCCESS) {
-        ers = "qv_scope_free() failed";
+        ers = "qv_free() failed";
         ctu_panic("%s (rc=%s)", ers, qv_strerr(rc));
     }
 #endif

--- a/tests/test-pthread-progr.c
+++ b/tests/test-pthread-progr.c
@@ -88,11 +88,11 @@ int mpi_impl_progr_thread_create(pthread_t *restrict thread,
   #else
   int qv_attr = QV_SCOPE_ATTR_SAME_NUMA | QV_SCOPE_ATTR_EXCLUSIVE;
   #endif
-  rc = qv_scope_create(ctx, base_scope,
+  rc = qv_create_scope(ctx, base_scope,
                QV_HW_OBJ_CORE, 1, qv_attr,
                &sub_scope);
   if (rc != QV_SUCCESS) {
-    ers = "qv_scope_create() failed";
+    ers = "qv_create_scope() failed";
     panic("%s (rc=%s)", ers, qv_strerr(rc));
   }
 

--- a/tests/test-pthread-split.c
+++ b/tests/test-pthread-split.c
@@ -33,18 +33,18 @@ main(void)
     fprintf(stdout,"# Starting Pthreads test.\n");
 
     qv_scope_t *base_scope;
-    int rc = qv_process_scope_get(
+    int rc = qv_process_scope(
         QV_SCOPE_PROCESS, QV_SCOPE_FLAG_NONE, &base_scope
     );
     if (rc != QV_SUCCESS) {
-        ers = "qv_process_scope_get() failed";
+        ers = "qv_process_scope() failed";
         ctu_panic("%s (rc=%s)", ers, qv_strerr(rc));
     }
 
     int ncores = 0;
-    rc = qv_scope_hw_obj_count(base_scope, QV_HW_OBJ_CORE, &ncores);
+    rc = qv_hw_obj_count(base_scope, QV_HW_OBJ_CORE, &ncores);
     if (rc != QV_SUCCESS) {
-        ers = "qv_scope_hw_obj_count() failed";
+        ers = "qv_hw_obj_count() failed";
         ctu_panic("%s (rc=%s)", ers, qv_strerr(rc));
     }
 
@@ -61,7 +61,7 @@ main(void)
     );
 
     qv_scope_t **th_scopes = NULL;
-    rc = qv_thread_scope_split(
+    rc = qv_thread_split(
         base_scope, npieces,
         QV_THREAD_SCOPE_SPLIT_PACKED,
         nthreads, &th_scopes
@@ -99,7 +99,7 @@ main(void)
         //fprintf(stdout,"Thread finished with '%s'\n", (char *)ret);
     }
     // Clean up.
-    rc = qv_thread_scopes_free(nthreads, th_scopes);
+    rc = qv_thread_free(nthreads, th_scopes);
     if (rc != QV_SUCCESS) {
         ers = "qv_pthread_scope_free() failed";
         ctu_panic("%s (rc=%s)", ers, qv_strerr(rc));
@@ -112,7 +112,7 @@ main(void)
         tid, nthreads, npieces
     );
 
-    rc = qv_thread_scope_split_at(
+    rc = qv_thread_split_at(
         base_scope, QV_HW_OBJ_CORE,
         QV_THREAD_SCOPE_SPLIT_PACKED,
         nthreads, &th_scopes
@@ -147,15 +147,15 @@ main(void)
         //fprintf(stdout,"Thread finished with '%s'\n", (char *)ret);
     }
     // Clean up.
-    rc = qv_thread_scopes_free(nthreads, th_scopes);
+    rc = qv_thread_free(nthreads, th_scopes);
     if (rc != QV_SUCCESS) {
         ers = "qv_pthread_scope_free() failed";
         ctu_panic("%s (rc=%s)", ers, qv_strerr(rc));
     }
 
-    rc = qv_scope_free(base_scope);
+    rc = qv_free(base_scope);
     if (rc != QV_SUCCESS) {
-        ers = "qv_scope_free() failed";
+        ers = "qv_free() failed";
         ctu_panic("%s (rc=%s)", ers, qv_strerr(rc));
     }
 


### PR DESCRIPTION
Remove use of redundant use of _scope in the user-facing API. QV is scope-centric, so can we just drop the qv_scope_ in favor of qv_.

Fixes #542