### PR TITLE
Enforce strict standard conformance flags.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,6 +27,8 @@ set(C_STANDARD_REQUIRED TRUE)
 
 # Specify the C++ standard.
 set(CMAKE_CXX_STANDARD 20)
+# Strip gnu prefix and enforces strict standard conformance flags.
+set(CMAKE_CXX_EXTENSIONS OFF)
 set(CXX_STANDARD_REQUIRED TRUE)
 
 # Append our module path.


### PR DESCRIPTION
This change may help with bogus C++20 conformance passes using older compilers.